### PR TITLE
Add example HIL library usage to GoDoc

### DIFF
--- a/example_func_test.go
+++ b/example_func_test.go
@@ -1,0 +1,54 @@
+package hil_test
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/hil"
+	"github.com/hashicorp/hil/ast"
+)
+
+func Example_functions() {
+	input := "${lower(var.test)} - ${6 + 2}"
+
+	tree, err := hil.Parse(input)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	lowerCase := ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString},
+		ReturnType: ast.TypeString,
+		Variadic:   false,
+		Callback: func(inputs []interface{}) (interface{}, error) {
+			input := inputs[0].(string)
+			return strings.ToLower(input), nil
+		},
+	}
+
+	config := &hil.EvalConfig{
+		GlobalScope: &ast.BasicScope{
+			VarMap: map[string]ast.Variable{
+				"var.test": ast.Variable{
+					Type:  ast.TypeString,
+					Value: "TEST STRING",
+				},
+			},
+			FuncMap: map[string]ast.Function{
+				"lower": lowerCase,
+			},
+		},
+	}
+
+	value, valueType, err := hil.Eval(tree, config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Type: %s\n", valueType)
+	fmt.Printf("Value: %s\n", value)
+	// Output:
+	// Type: TypeString
+	// Value: test string - 8
+}

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,28 @@
+package hil_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/hil"
+)
+
+func Example_basic() {
+	input := "${6 + 2}"
+
+	tree, err := hil.Parse(input)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	value, valueType, err := hil.Eval(tree, &hil.EvalConfig{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Type: %s\n", valueType)
+	fmt.Printf("Value: %s\n", value)
+	// Output:
+	// Type: TypeString
+	// Value: 8
+}

--- a/example_var_test.go
+++ b/example_var_test.go
@@ -1,0 +1,40 @@
+package hil_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/hil"
+	"github.com/hashicorp/hil/ast"
+)
+
+func Example_variables() {
+	input := "${var.test} - ${6 + 2}"
+
+	tree, err := hil.Parse(input)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	config := &hil.EvalConfig{
+		GlobalScope: &ast.BasicScope{
+			VarMap: map[string]ast.Variable{
+				"var.test": ast.Variable{
+					Type:  ast.TypeString,
+					Value: "TEST STRING",
+				},
+			},
+		},
+	}
+
+	value, valueType, err := hil.Eval(tree, config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Type: %s\n", valueType)
+	fmt.Printf("Value: %s\n", value)
+	// Output:
+	// Type: TypeString
+	// Value: TEST STRING - 8
+}


### PR DESCRIPTION
This pull request adds three examples of using HIL - one for simple arithmetic, one with variable access, and one with a function call. They are added as GoDoc examples so they will run as part of the tests.