### PR TITLE
Improve error when concat output is not a string

### DIFF
--- a/check_types.go
+++ b/check_types.go
@@ -251,7 +251,7 @@ func (tc *typeCheckConcat) TypeCheck(v *TypeCheck) (ast.Node, error) {
 			}
 
 			return nil, fmt.Errorf(
-				"argument %d must be a string", i+1)
+				"output of an HIL expression must be a string (argument %d is %s)", i+1, t)
 		}
 	}
 


### PR DESCRIPTION
This commit changes the error message returned when the arguments to concat type check as something other than a string, to indicate that it is the entire HIL expression that needs to result in a string.

The previous behaviour made debugging in consumers difficult when the expression consisted of a function which took a string as an argument and returned something other than a string.