### PR TITLE
Add implicit conversion of string to float

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -22,6 +22,7 @@ func registerBuiltins(scope *ast.BasicScope) *ast.BasicScope {
 	scope.FuncMap["__builtin_IntToFloat"] = builtinIntToFloat()
 	scope.FuncMap["__builtin_IntToString"] = builtinIntToString()
 	scope.FuncMap["__builtin_StringToInt"] = builtinStringToInt()
+	scope.FuncMap["__builtin_StringToFloat"] = builtinStringToFloat()
 
 	// Math operations
 	scope.FuncMap["__builtin_IntMath"] = builtinIntMath()
@@ -139,6 +140,21 @@ func builtinStringToInt() ast.Function {
 			}
 
 			return int(v), nil
+		},
+	}
+}
+
+func builtinStringToFloat() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString},
+		ReturnType: ast.TypeFloat,
+		Callback: func(args []interface{}) (interface{}, error) {
+			v, err := strconv.ParseFloat(args[0].(string), 64)
+			if err != nil {
+				return nil, err
+			}
+
+			return v, nil
 		},
 	}
 }

--- a/eval.go
+++ b/eval.go
@@ -41,7 +41,8 @@ func Eval(root ast.Node, config *EvalConfig) (interface{}, ast.Type, error) {
 			ast.TypeString: "__builtin_IntToString",
 		},
 		ast.TypeString: {
-			ast.TypeInt: "__builtin_StringToInt",
+			ast.TypeInt:   "__builtin_StringToInt",
+			ast.TypeFloat: "__builtin_StringToFloat",
 		},
 	}
 

--- a/eval_test.go
+++ b/eval_test.go
@@ -474,6 +474,22 @@ func TestEval(t *testing.T) {
 			"foo 43",
 			ast.TypeString,
 		},
+
+		// String vars should be able to implictly convert to floats
+		{
+			"${1.5 * var.foo}",
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"var.foo": ast.Variable{
+						Value: "42",
+						Type:  ast.TypeString,
+					},
+				},
+			},
+			false,
+			"63",
+			ast.TypeString,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Needed in Terraform to allow float math involving variables, because
variables are all strings.