### PR TITLE
Allow HIL evaluation to return a TypeList

### DIFF
--- a/check_types.go
+++ b/check_types.go
@@ -241,7 +241,13 @@ func (tc *typeCheckConcat) TypeCheck(v *TypeCheck) (ast.Node, error) {
 		types[len(n.Exprs)-1-i] = v.StackPop()
 	}
 
-	// All concat args must be strings, so validate that
+	// If there is only one argument and it is a list, we evaluate to a list
+	if len(types) == 1 && types[0] == ast.TypeList {
+		v.StackPush(ast.TypeList)
+		return n, nil
+	}
+
+	// Otherwise, all concat args must be strings, so validate that
 	for i, t := range types {
 		if t != ast.TypeString {
 			cn := v.ImplicitConversion(t, ast.TypeString, n.Exprs[i])
@@ -251,7 +257,7 @@ func (tc *typeCheckConcat) TypeCheck(v *TypeCheck) (ast.Node, error) {
 			}
 
 			return nil, fmt.Errorf(
-				"output of an HIL expression must be a string (argument %d is %s)", i+1, t)
+				"output of an HIL expression must be a string, or a single list (argument %d is %s)", i+1, t)
 		}
 	}
 

--- a/eval.go
+++ b/eval.go
@@ -244,6 +244,12 @@ func (v *evalConcat) Eval(s ast.Scope, stack *ast.Stack) (interface{}, ast.Type,
 		nodes = append(nodes, stack.Pop().(*ast.LiteralNode))
 	}
 
+	// Special case the single list
+	if len(nodes) == 1 && nodes[0].Typex == ast.TypeList {
+		return nodes[0].Value, ast.TypeList, nil
+	}
+
+	// Otherwise concatenate the strings
 	var buf bytes.Buffer
 	for i := len(nodes) - 1; i >= 0; i-- {
 		buf.WriteString(nodes[i].Value.(string))

--- a/eval_test.go
+++ b/eval_test.go
@@ -40,6 +40,39 @@ func TestEval(t *testing.T) {
 		},
 
 		{
+			"${var.alist}",
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"var.alist": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "Hello",
+							},
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "World",
+							},
+						},
+					},
+				},
+			},
+			false,
+			[]ast.Variable{
+				ast.Variable{
+					Type:  ast.TypeString,
+					Value: "Hello",
+				},
+				ast.Variable{
+					Type:  ast.TypeString,
+					Value: "World",
+				},
+			},
+			ast.TypeList,
+		},
+
+		{
 			"foo ${-29}",
 			nil,
 			false,
@@ -380,6 +413,78 @@ func TestEval(t *testing.T) {
 			},
 			false,
 			"aaa 24 - 42",
+			ast.TypeString,
+		},
+
+		{
+			"${var.foo} ${var.foo[0]}",
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"var.foo": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "hello",
+							},
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "world",
+							},
+						},
+					},
+				},
+			},
+			true,
+			nil,
+			ast.TypeInvalid,
+		},
+
+		{
+			"${var.foo[0]} ${var.foo[1]}",
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"var.foo": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "hello",
+							},
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "world",
+							},
+						},
+					},
+				},
+			},
+			false,
+			"hello world",
+			ast.TypeString,
+		},
+
+		{
+			"${foo[1]} ${foo[0]}",
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							ast.Variable{
+								Type:  ast.TypeInt,
+								Value: 42,
+							},
+							ast.Variable{
+								Type:  ast.TypeInt,
+								Value: 24,
+							},
+						},
+					},
+				},
+			},
+			false,
+			"24 42",
 			ast.TypeString,
 		},
 


### PR DESCRIPTION
In order to allow outputs which interpolate to lists to resolve correctly in Terraform, and to allow the potential to return maps, we need to break the model of always returning a string from interpolations.

The best way to do this while maintaining backwards compatibility appears to be the following precedence:

Assuming we have a scope which looks like the following:

```
Variables:
    var.alist = ["hello", "world"]
Functions:
    // None except the builtins
```

The following rules apply:

```
Input: "${var.alist}"
Output from hil.Eval(...) (interface{}, Type, error):
    []ast.Variable{
        ast.Variable{
            Type: ast.TypeString,
            Value: "hello",
        },
        ast.Variable{
            Type: ast.TypeString,
            Value: "world",
        },
    },
    ast.TypeList,
    nil
```

```
Input: "${var.alist[0]} ${var.alist[1]}"
Output from hil.Eval(...) (interface{}, Type, error):
    "hello world",
    ast.TypeString,
    nil
```

```
Input: "${var.alist} ${var.alist[0]}"
Output from hil.Eval(...) (interface{}, Type, error):
    nil,
    ast.TypeInvalid,
    an error (from type checker)
```

This is easy to extend out to allow maps to be returned later on. It may, however, need revisiting to ensure that all list items are rendered as strings via the implicit conversion mechanisms (this should be informed by the remaining development left to be done on Terraform outputs).

cc: @mitchellh or @phinze for review.