### PR TITLE
Dynamic lookup of env vars

### DIFF
--- a/ast/scope.go
+++ b/ast/scope.go
@@ -2,7 +2,9 @@ package ast
 
 import (
 	"fmt"
+	"os"
 	"reflect"
+	"strings"
 )
 
 // Scope is the interface used to look up variables and functions while
@@ -83,6 +85,18 @@ func (s *BasicScope) LookupFunc(n string) (Function, bool) {
 func (s *BasicScope) LookupVar(n string) (Variable, bool) {
 	if s == nil {
 		return Variable{}, false
+	}
+
+	var v Variable
+
+	if strings.HasPrefix(n, "env.") {
+		name := strings.TrimLeft(n, "env.")
+		v = Variable{
+			Type:  TypeString,
+			Value: os.Getenv(name),
+		}
+
+		return v, true
 	}
 
 	v, ok := s.VarMap[n]


### PR DESCRIPTION
This PR adds support for dynamically looking up env vars when the variable name starts with `env.`.

Example:

```
foo = "hi ${var.NAME}"
```

I've done this within the existing `BasicScope` implementation of the `Scope` interface. I had initially tried to create and use a different implementation of the `Scope` interface but couldn't use it as `BasicScope` is explicitly required here: https://github.com/hashicorp/hil/blob/1586b586f59cfa528a751d4a62be88910d34e6e9/builtins.go#L11

Alternate suggestions on how to do this welcome!