### PR TITLE
Add support for indexing map variables

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -53,4 +53,5 @@ const (
 	TypeInt
 	TypeFloat
 	TypeList
+	TypeMap
 )

--- a/ast/index_test.go
+++ b/ast/index_test.go
@@ -1,10 +1,170 @@
 package ast
 
 import (
+	"strings"
 	"testing"
 )
 
-func TestIndexType_string(t *testing.T) {
+func TestIndexTypeMap_empty(t *testing.T) {
+	i := &Index{
+		Target: &VariableAccess{Name: "foo"},
+		Key: &LiteralNode{
+			Typex: TypeString,
+			Value: "bar",
+		},
+	}
+
+	scope := &BasicScope{
+		VarMap: map[string]Variable{
+			"foo": Variable{
+				Type:  TypeMap,
+				Value: map[string]Variable{},
+			},
+		},
+	}
+
+	actual, err := i.Type(scope)
+	if err == nil || !strings.Contains(err.Error(), "does not have any elements") {
+		t.Fatalf("bad err: %s", err)
+	}
+	if actual != TypeInvalid {
+		t.Fatalf("bad: %s", actual)
+	}
+}
+
+func TestIndexTypeMap_string(t *testing.T) {
+	i := &Index{
+		Target: &VariableAccess{Name: "foo"},
+		Key: &LiteralNode{
+			Typex: TypeString,
+			Value: "bar",
+		},
+	}
+
+	scope := &BasicScope{
+		VarMap: map[string]Variable{
+			"foo": Variable{
+				Type: TypeMap,
+				Value: map[string]Variable{
+					"baz": Variable{
+						Type:  TypeString,
+						Value: "Hello",
+					},
+					"bar": Variable{
+						Type:  TypeString,
+						Value: "World",
+					},
+				},
+			},
+		},
+	}
+
+	actual, err := i.Type(scope)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if actual != TypeString {
+		t.Fatalf("bad: %s", actual)
+	}
+}
+
+func TestIndexTypeMap_int(t *testing.T) {
+	i := &Index{
+		Target: &VariableAccess{Name: "foo"},
+		Key: &LiteralNode{
+			Typex: TypeString,
+			Value: "bar",
+		},
+	}
+
+	scope := &BasicScope{
+		VarMap: map[string]Variable{
+			"foo": Variable{
+				Type: TypeMap,
+				Value: map[string]Variable{
+					"baz": Variable{
+						Type:  TypeInt,
+						Value: 1,
+					},
+					"bar": Variable{
+						Type:  TypeInt,
+						Value: 2,
+					},
+				},
+			},
+		},
+	}
+
+	actual, err := i.Type(scope)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if actual != TypeInt {
+		t.Fatalf("bad: %s", actual)
+	}
+}
+
+func TestIndexTypeMap_nonHomogenous(t *testing.T) {
+	i := &Index{
+		Target: &VariableAccess{Name: "foo"},
+		Key: &LiteralNode{
+			Typex: TypeString,
+			Value: "bar",
+		},
+	}
+
+	scope := &BasicScope{
+		VarMap: map[string]Variable{
+			"foo": Variable{
+				Type: TypeMap,
+				Value: map[string]Variable{
+					"bar": Variable{
+						Type:  TypeString,
+						Value: "Hello",
+					},
+					"baz": Variable{
+						Type:  TypeInt,
+						Value: 43,
+					},
+				},
+			},
+		},
+	}
+
+	_, err := i.Type(scope)
+	if err == nil || !strings.Contains(err.Error(), "homogenous") {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestIndexTypeList_empty(t *testing.T) {
+	i := &Index{
+		Target: &VariableAccess{Name: "foo"},
+		Key: &LiteralNode{
+			Typex: TypeInt,
+			Value: 1,
+		},
+	}
+
+	scope := &BasicScope{
+		VarMap: map[string]Variable{
+			"foo": Variable{
+				Type:  TypeList,
+				Value: []Variable{},
+			},
+		},
+	}
+
+	actual, err := i.Type(scope)
+	if err == nil || !strings.Contains(err.Error(), "does not have any elements") {
+		t.Fatalf("bad err: %s", err)
+	}
+	if actual != TypeInvalid {
+		t.Fatalf("bad: %s", actual)
+	}
+}
+
+func TestIndexTypeList_string(t *testing.T) {
 	i := &Index{
 		Target: &VariableAccess{Name: "foo"},
 		Key: &LiteralNode{
@@ -40,7 +200,7 @@ func TestIndexType_string(t *testing.T) {
 	}
 }
 
-func TestIndexType_int(t *testing.T) {
+func TestIndexTypeList_int(t *testing.T) {
 	i := &Index{
 		Target: &VariableAccess{Name: "foo"},
 		Key: &LiteralNode{
@@ -76,7 +236,7 @@ func TestIndexType_int(t *testing.T) {
 	}
 }
 
-func TestIndexType_nonHomogenous(t *testing.T) {
+func TestIndexTypeList_nonHomogenous(t *testing.T) {
 	i := &Index{
 		Target: &VariableAccess{Name: "foo"},
 		Key: &LiteralNode{
@@ -104,7 +264,7 @@ func TestIndexType_nonHomogenous(t *testing.T) {
 	}
 
 	_, err := i.Type(scope)
-	if err == nil {
+	if err == nil || !strings.Contains(err.Error(), "homogenous") {
 		t.Fatalf("expected error")
 	}
 }

--- a/ast/variables_helper.go
+++ b/ast/variables_helper.go
@@ -1,0 +1,45 @@
+package ast
+
+import "fmt"
+
+func VariableListElementTypesAreHomogenous(variableName string, list []Variable) (Type, error) {
+	listTypes := make(map[Type]struct{})
+	for _, v := range list {
+		if _, ok := listTypes[v.Type]; ok {
+			continue
+		}
+		listTypes[v.Type] = struct{}{}
+	}
+
+	if len(listTypes) != 1 && len(list) != 0 {
+		return TypeInvalid, fmt.Errorf("list %q does not have homogenous types. found %s", variableName, reportTypes(listTypes))
+	}
+
+	if len(list) > 0 {
+		return list[0].Type, nil
+	}
+
+	return TypeInvalid, fmt.Errorf("list %q does not have any elements so cannot determine type.", variableName)
+}
+
+func VariableMapValueTypesAreHomogenous(variableName string, vmap map[string]Variable) (Type, error) {
+	valueTypes := make(map[Type]struct{})
+	for _, v := range vmap {
+		if _, ok := valueTypes[v.Type]; ok {
+			continue
+		}
+		valueTypes[v.Type] = struct{}{}
+	}
+
+	if len(valueTypes) != 1 && len(vmap) != 0 {
+		return TypeInvalid, fmt.Errorf("map %q does not have homogenous value types. found %s", variableName, reportTypes(valueTypes))
+	}
+
+	// For loop here is an easy way to get a single key, we return immediately.
+	for _, v := range vmap {
+		return v.Type, nil
+	}
+
+	// This means the map is empty
+	return TypeInvalid, fmt.Errorf("map %q does not have any elements so cannot determine type.", variableName)
+}

--- a/check_types_test.go
+++ b/check_types_test.go
@@ -306,6 +306,45 @@ func TestTypeCheck_implicit(t *testing.T) {
 			},
 			false,
 		},
+
+		{
+			`${foo[bar[var.keyint]]}`,
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeMap,
+						Value: map[string]ast.Variable{
+							"foo": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "hello",
+							},
+							"bar": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "world",
+							},
+						},
+					},
+					"bar": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "i dont exist",
+							},
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "bar",
+							},
+						},
+					},
+					"var.key": ast.Variable{
+						Type:  ast.TypeInt,
+						Value: 1,
+					},
+				},
+			},
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/eval.go
+++ b/eval.go
@@ -200,16 +200,35 @@ func (v *evalIndex) Eval(scope ast.Scope, stack *ast.Stack) (interface{}, ast.Ty
 	if err != nil {
 		return nil, ast.TypeInvalid, err
 	}
+
 	key, keyType, err := evalKey.Eval(scope, stack)
-
-	// Last sanity check
-	if targetType != ast.TypeList {
-		return nil, ast.TypeInvalid, fmt.Errorf("target for indexing must be ast.TypeList, is %s", targetType)
-	}
-	if keyType != ast.TypeInt {
-		return nil, ast.TypeInvalid, fmt.Errorf("key for indexing must be ast.TypeInt, is %s", keyType)
+	if err != nil {
+		return nil, ast.TypeInvalid, err
 	}
 
+	variableName := v.Index.Target.(*ast.VariableAccess).Name
+
+	switch targetType {
+	case ast.TypeList:
+		if keyType != ast.TypeInt {
+			return nil, ast.TypeInvalid, fmt.Errorf("key for indexing list %q must be an int, is %s", variableName, keyType)
+		}
+
+		return v.evalListIndex(variableName, target, key)
+	case ast.TypeMap:
+		if keyType != ast.TypeString {
+			return nil, ast.TypeInvalid, fmt.Errorf("key for indexing map %q must be a string, is %s", variableName, keyType)
+		}
+
+		return v.evalMapIndex(variableName, target, key)
+	default:
+		return nil, ast.TypeInvalid, fmt.Errorf("target %q for indexing must be ast.TypeList or ast.TypeMap, is %s", variableName, targetType)
+	}
+}
+
+func (v *evalIndex) evalListIndex(variableName string, target interface{}, key interface{}) (interface{}, ast.Type, error) {
+	// We assume type checking was already done and we can assume that target
+	// is a list and key is an int
 	list, ok := target.([]ast.Variable)
 	if !ok {
 		return nil, ast.TypeInvalid, fmt.Errorf("cannot cast target to []Variable")
@@ -225,13 +244,38 @@ func (v *evalIndex) Eval(scope ast.Scope, stack *ast.Stack) (interface{}, ast.Ty
 	}
 
 	if keyInt < 0 || len(list) < keyInt+1 {
-		return nil, ast.TypeInvalid, fmt.Errorf("index %d out of range (max %d)", keyInt, len(list))
+		return nil, ast.TypeInvalid, fmt.Errorf("index %d out of range for list %s (max %d)", keyInt, variableName, len(list))
 	}
 
 	returnVal := list[keyInt].Value
 	returnType := list[keyInt].Type
 
 	return returnVal, returnType, nil
+}
+
+func (v *evalIndex) evalMapIndex(variableName string, target interface{}, key interface{}) (interface{}, ast.Type, error) {
+	// We assume type checking was already done and we can assume that target
+	// is a map and key is a string
+	vmap, ok := target.(map[string]ast.Variable)
+	if !ok {
+		return nil, ast.TypeInvalid, fmt.Errorf("cannot cast target to map[string]Variable")
+	}
+
+	keyString, ok := key.(string)
+	if !ok {
+		return nil, ast.TypeInvalid, fmt.Errorf("cannot cast key to string")
+	}
+
+	if len(vmap) == 0 {
+		return nil, ast.TypeInvalid, fmt.Errorf("map is empty")
+	}
+
+	value, ok := vmap[keyString]
+	if !ok {
+		return nil, ast.TypeInvalid, fmt.Errorf("key %q does not exist in map %s", keyString, variableName)
+	}
+
+	return value.Value, value.Type, nil
 }
 
 type evalConcat struct{ *ast.Concat }

--- a/eval_test.go
+++ b/eval_test.go
@@ -265,6 +265,160 @@ func TestEval(t *testing.T) {
 		},
 
 		{
+			`${foo["bar"]}`,
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "hello",
+							},
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "world",
+							},
+						},
+					},
+				},
+			},
+			true,
+			nil,
+			ast.TypeInvalid,
+		},
+
+		{
+			`${foo["bar"]}`,
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeMap,
+						Value: map[string]ast.Variable{
+							"foo": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "hello",
+							},
+							"bar": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "world",
+							},
+						},
+					},
+				},
+			},
+			false,
+			"world",
+			ast.TypeString,
+		},
+
+		{
+			`${foo[var.key]}`,
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeMap,
+						Value: map[string]ast.Variable{
+							"foo": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "hello",
+							},
+							"bar": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "world",
+							},
+						},
+					},
+					"var.key": ast.Variable{
+						Type:  ast.TypeString,
+						Value: "bar",
+					},
+				},
+			},
+			false,
+			"world",
+			ast.TypeString,
+		},
+
+		{
+			`${foo[bar[var.keyint]]}`,
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeMap,
+						Value: map[string]ast.Variable{
+							"foo": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "hello",
+							},
+							"bar": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "world",
+							},
+						},
+					},
+					"bar": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "i dont exist",
+							},
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "bar",
+							},
+						},
+					},
+					"var.keyint": ast.Variable{
+						Type:  ast.TypeInt,
+						Value: 1,
+					},
+				},
+			},
+			false,
+			"world",
+			ast.TypeString,
+		},
+
+		{
+			`${foo["bar"]} ${bar[1]}`,
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeMap,
+						Value: map[string]ast.Variable{
+							"foo": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "hello",
+							},
+							"bar": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "world",
+							},
+						},
+					},
+					"bar": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							ast.Variable{
+								Type:  ast.TypeInt,
+								Value: 10,
+							},
+							ast.Variable{
+								Type:  ast.TypeInt,
+								Value: 20,
+							},
+						},
+					},
+				},
+			},
+			false,
+			"world 20",
+			ast.TypeString,
+		},
+
+		{
 			"${foo[0]}",
 			&ast.BasicScope{
 				VarMap: map[string]ast.Variable{


### PR DESCRIPTION
This adds support for indexing into variables of the new type "Map". The syntax is typical Go-style map syntax, so for example, the following is valid for interpolating the value of the map foo at key "bar":

    `${foo["bar"]}`

There is a restriction that map values must be homogenous in type. This is to enable the type checker to work without having to actually perform the indexing operation. This is a similar restriction to that placed on lists.

During discussion there was no compelling use case for maps or lists of heterogenous types - this is open for discussion in future though if one is found.

This also expands out the range of test cases covered for lists during type checking and evaluation to include empty lists.