### PR TITLE
Add functions to convert Go to HIL structures

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -1,0 +1,54 @@
+package hil
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hil/ast"
+	"github.com/mitchellh/mapstructure"
+)
+
+func InterfaceToVariable(input interface{}) (ast.Variable, error) {
+	var stringVal string
+	if err := mapstructure.WeakDecode(input, &stringVal); err == nil {
+		return ast.Variable{
+			Type:  ast.TypeString,
+			Value: stringVal,
+		}, nil
+	}
+
+	var sliceVal []interface{}
+	if err := mapstructure.WeakDecode(input, &sliceVal); err == nil {
+		elements := make([]ast.Variable, len(sliceVal))
+		for i, element := range sliceVal {
+			varElement, err := InterfaceToVariable(element)
+			if err != nil {
+				return ast.Variable{}, err
+			}
+			elements[i] = varElement
+		}
+
+		return ast.Variable{
+			Type:  ast.TypeList,
+			Value: elements,
+		}, nil
+	}
+
+	var mapVal map[string]interface{}
+	if err := mapstructure.WeakDecode(input, &mapVal); err == nil {
+		elements := make(map[string]ast.Variable)
+		for i, element := range mapVal {
+			varElement, err := InterfaceToVariable(element)
+			if err != nil {
+				return ast.Variable{}, err
+			}
+			elements[i] = varElement
+		}
+
+		return ast.Variable{
+			Type:  ast.TypeMap,
+			Value: elements,
+		}, nil
+	}
+
+	return ast.Variable{}, fmt.Errorf("value for conversion must be a string, interface{} or map[string]interface: got %T", input)
+}

--- a/convert_test.go
+++ b/convert_test.go
@@ -1,0 +1,143 @@
+package hil
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/hil/ast"
+)
+
+func TestInterfaceToVariable(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    interface{}
+		expected ast.Variable
+	}{
+		{
+			name:  "string",
+			input: "Hello world",
+			expected: ast.Variable{
+				Type:  ast.TypeString,
+				Value: "Hello world",
+			},
+		},
+		{
+			name:  "list of strings",
+			input: []string{"Hello", "World"},
+			expected: ast.Variable{
+				Type: ast.TypeList,
+				Value: []ast.Variable{
+					ast.Variable{
+						Type:  ast.TypeString,
+						Value: "Hello",
+					},
+					ast.Variable{
+						Type:  ast.TypeString,
+						Value: "World",
+					},
+				},
+			},
+		},
+		{
+			name:  "list of lists of strings",
+			input: [][]string{[]string{"Hello", "World"}, []string{"Goodbye", "World"}},
+			expected: ast.Variable{
+				Type: ast.TypeList,
+				Value: []ast.Variable{
+					ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "Hello",
+							},
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "World",
+							},
+						},
+					},
+					ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "Goodbye",
+							},
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "World",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "map of string->string",
+			input: map[string]string{"Hello": "World", "Foo": "Bar"},
+			expected: ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"Hello": ast.Variable{
+						Type:  ast.TypeString,
+						Value: "World",
+					},
+					"Foo": ast.Variable{
+						Type:  ast.TypeString,
+						Value: "Bar",
+					},
+				},
+			},
+		},
+		{
+			name: "map of lists of strings",
+			input: map[string][]string{
+				"Hello":   []string{"Hello", "World"},
+				"Goodbye": []string{"Goodbye", "World"},
+			},
+			expected: ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"Hello": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "Hello",
+							},
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "World",
+							},
+						},
+					},
+					"Goodbye": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "Goodbye",
+							},
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "World",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		output, err := InterfaceToVariable(tc.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(output, tc.expected) {
+			t.Fatalf("%s:\nExpected: %s\n     Got: %s\n", tc.name, tc.expected, output)
+		}
+	}
+}


### PR DESCRIPTION
This adds convenience functions for converting a Go type such as string, []interface{} and map[string]interface{} into their ast.Variable-based representations for use in interpolations.