### PR TITLE
Fix conversion for empty interface slices

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -9,7 +9,7 @@ import (
 
 func InterfaceToVariable(input interface{}) (ast.Variable, error) {
 	var stringVal string
-	if err := mapstructure.WeakDecode(input, &stringVal); err == nil {
+	if err := mapstructure.Decode(input, &stringVal); err == nil {
 		return ast.Variable{
 			Type:  ast.TypeString,
 			Value: stringVal,
@@ -17,7 +17,7 @@ func InterfaceToVariable(input interface{}) (ast.Variable, error) {
 	}
 
 	var mapVal map[string]interface{}
-	if err := mapstructure.WeakDecode(input, &mapVal); err == nil {
+	if err := mapstructure.Decode(input, &mapVal); err == nil {
 		elements := make(map[string]ast.Variable)
 		for i, element := range mapVal {
 			varElement, err := InterfaceToVariable(element)
@@ -34,7 +34,7 @@ func InterfaceToVariable(input interface{}) (ast.Variable, error) {
 	}
 
 	var sliceVal []interface{}
-	if err := mapstructure.WeakDecode(input, &sliceVal); err == nil {
+	if err := mapstructure.Decode(input, &sliceVal); err == nil {
 		elements := make([]ast.Variable, len(sliceVal))
 		for i, element := range sliceVal {
 			varElement, err := InterfaceToVariable(element)

--- a/convert_test.go
+++ b/convert_test.go
@@ -22,6 +22,14 @@ func TestInterfaceToVariable(t *testing.T) {
 			},
 		},
 		{
+			name:  "empty list",
+			input: []interface{}{},
+			expected: ast.Variable{
+				Type:  ast.TypeList,
+				Value: []ast.Variable{},
+			},
+		},
+		{
 			name:  "list of strings",
 			input: []string{"Hello", "World"},
 			expected: ast.Variable{


### PR DESCRIPTION
Because of an awkward backward compatibility construct in mapstructure when using WeakDecode, the test added in this commit fails without the change
to use Decode over WeakDecode, in the following manner:

```
$ go test ./...
--- FAIL: TestInterfaceToVariable (0.00s)
	convert_test.go:181: empty list:
		Expected: {Variable (TypeList): []}
		     Got: {Variable (TypeMap): map[]}
FAIL
FAIL	github.com/hashicorp/hil	0.008s
ok  	github.com/hashicorp/hil/ast	0.007s
```

This PR fixes the test, and leads to behaviour which follows the principle of least surprise: empty lists are no longer converted to empty maps!