### PR TITLE
Use WeakDecode for conversions

### DIFF
--- a/convert_test.go
+++ b/convert_test.go
@@ -30,6 +30,14 @@ func TestInterfaceToVariable(t *testing.T) {
 			},
 		},
 		{
+			name:  "int",
+			input: 1,
+			expected: ast.Variable{
+				Type:  ast.TypeString,
+				Value: "1",
+			},
+		},
+		{
 			name:  "list of strings",
 			input: []string{"Hello", "World"},
 			expected: ast.Variable{


### PR DESCRIPTION
The previous fix lacked some nuance - we fixed empty lists at the expense of other primitive types. Instead of using Decode, we now defeat the backward compatibility mechanism in mapstructure with a DecodeHook instead.

cc @phinze, @mitchellh