### PR TITLE
Defeat mapstructure backward compat for []string

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -8,8 +8,9 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-var hilMapstructureDecodeHookEmptySlice []interface{}
-var hilMapstructureDecodeHookEmptyMap map[string]interface{}
+var hilMapstructureDecodeHookSlice []interface{}
+var hilMapstructureDecodeHookStringSlice []string
+var hilMapstructureDecodeHookMap map[string]interface{}
 
 // hilMapstructureWeakDecode behaves in the same way as mapstructure.WeakDecode
 // but has a DecodeHook which defeats the backward compatibility mode of mapstructure
@@ -18,11 +19,12 @@ var hilMapstructureDecodeHookEmptyMap map[string]interface{}
 func hilMapstructureWeakDecode(m interface{}, rawVal interface{}) error {
 	config := &mapstructure.DecoderConfig{
 		DecodeHook: func(source reflect.Type, target reflect.Type, val interface{}) (interface{}, error) {
-			sliceType := reflect.TypeOf(hilMapstructureDecodeHookEmptySlice)
-			mapType := reflect.TypeOf(hilMapstructureDecodeHookEmptyMap)
+			sliceType := reflect.TypeOf(hilMapstructureDecodeHookSlice)
+			stringSliceType := reflect.TypeOf(hilMapstructureDecodeHookStringSlice)
+			mapType := reflect.TypeOf(hilMapstructureDecodeHookMap)
 
-			if source == sliceType && target == mapType {
-				return nil, fmt.Errorf("Cannot convert a []interface{} into a map[string]interface{}")
+			if (source == sliceType || source == stringSliceType) && target == mapType {
+				return nil, fmt.Errorf("Cannot convert %s into a %s", source, target)
 			}
 
 			return val, nil

--- a/convert_test.go
+++ b/convert_test.go
@@ -30,6 +30,14 @@ func TestInterfaceToVariable(t *testing.T) {
 			},
 		},
 		{
+			name:  "empty list of strings",
+			input: []string{},
+			expected: ast.Variable{
+				Type:  ast.TypeList,
+				Value: []ast.Variable{},
+			},
+		},
+		{
 			name:  "int",
 			input: 1,
 			expected: ast.Variable{


### PR DESCRIPTION
Previously this fix only applied to `[]interface{}`, but there are places in Terraform where we use the `interfaceToHILVariable` function with `[]string`, which was erroneously converting `[]string{}` to `map[string]interface{}{}` in order to preserve backwards compatibility. We now check for `[]string` in addition to `[]interface{}` in our workaround for this.

cc @phinze, @mitchellh