### PR TITLE
Pretty print types in error messages

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -55,3 +55,24 @@ const (
 	TypeList
 	TypeMap
 )
+
+func (t Type) Printable() string {
+	switch t {
+	case TypeInvalid:
+		return "invalid type"
+	case TypeAny:
+		return "any type"
+	case TypeString:
+		return "type string"
+	case TypeInt:
+		return "type int"
+	case TypeFloat:
+		return "type float"
+	case TypeList:
+		return "type list"
+	case TypeMap:
+		return "type map"
+	default:
+		return "unknown type"
+	}
+}

--- a/check_types.go
+++ b/check_types.go
@@ -199,7 +199,7 @@ func (tc *typeCheckCall) TypeCheck(v *TypeCheck) (ast.Node, error) {
 
 			return nil, fmt.Errorf(
 				"%s: argument %d should be %s, got %s",
-				tc.n.Func, i+1, expected, args[i])
+				tc.n.Func, i+1, expected.Printable(), args[i].Printable())
 		}
 	}
 
@@ -219,7 +219,7 @@ func (tc *typeCheckCall) TypeCheck(v *TypeCheck) (ast.Node, error) {
 				return nil, fmt.Errorf(
 					"%s: argument %d should be %s, got %s",
 					tc.n.Func, realI,
-					function.VariadicType, t)
+					function.VariadicType.Printable(), t.Printable())
 			}
 		}
 	}


### PR DESCRIPTION
This results in nicer error mesages when type checking fails in Terraform:

```
$ terraform apply
There are warnings and/or errors related to your configuration. Please
fix these before continuing.

Errors:

  * At column 3, line 1: join: argument 1 should be TypeList, got TypeString in:

${join(",", var.astring)}
```

becomes:

```
$ terraform apply
There are warnings and/or errors related to your configuration. Please
fix these before continuing.

Errors:

  * At column 3, line 1: join: argument 1 should be type list, got type string in:

${join(",", var.astring)}
```