### PR TITLE
Expand all ast.Variables on evaluation

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -86,3 +86,59 @@ func InterfaceToVariable(input interface{}) (ast.Variable, error) {
 
 	return ast.Variable{}, fmt.Errorf("value for conversion must be a string, interface{} or map[string]interface: got %T", input)
 }
+
+func VariableToInterface(input ast.Variable) (interface{}, error) {
+	if input.Type == ast.TypeString {
+		if inputStr, ok := input.Value.(string); ok {
+			return inputStr, nil
+		} else {
+			return nil, fmt.Errorf("ast.Variable with type string has value which is not a string")
+		}
+	}
+
+	if input.Type == ast.TypeList {
+		inputList, ok := input.Value.([]ast.Variable)
+		if !ok {
+			return nil, fmt.Errorf("ast.Variable with type list has value which is not a []ast.Variable")
+		}
+
+		result := make([]interface{}, 0)
+		if len(inputList) == 0 {
+			return result, nil
+		}
+
+		for _, element := range inputList {
+			if convertedElement, err := VariableToInterface(element); err == nil {
+				result = append(result, convertedElement)
+			} else {
+				return nil, err
+			}
+		}
+
+		return result, nil
+	}
+
+	if input.Type == ast.TypeMap {
+		inputMap, ok := input.Value.(map[string]ast.Variable)
+		if !ok {
+			return nil, fmt.Errorf("ast.Variable with type map has value which is not a map[string]ast.Variable")
+		}
+
+		result := make(map[string]interface{}, 0)
+		if len(inputMap) == 0 {
+			return result, nil
+		}
+
+		for key, value := range inputMap {
+			if convertedValue, err := VariableToInterface(value); err == nil {
+				result[key] = convertedValue
+			} else {
+				return nil, err
+			}
+		}
+
+		return result, nil
+	}
+
+	return nil, fmt.Errorf("Find")
+}

--- a/convert_test.go
+++ b/convert_test.go
@@ -51,11 +51,11 @@ func TestInterfaceToVariable(t *testing.T) {
 			expected: ast.Variable{
 				Type: ast.TypeList,
 				Value: []ast.Variable{
-					ast.Variable{
+					{
 						Type:  ast.TypeString,
 						Value: "Hello",
 					},
-					ast.Variable{
+					{
 						Type:  ast.TypeString,
 						Value: "World",
 					},
@@ -64,31 +64,31 @@ func TestInterfaceToVariable(t *testing.T) {
 		},
 		{
 			name:  "list of lists of strings",
-			input: [][]string{[]string{"Hello", "World"}, []string{"Goodbye", "World"}},
+			input: [][]interface{}{[]interface{}{"Hello", "World"}, []interface{}{"Goodbye", "World"}},
 			expected: ast.Variable{
 				Type: ast.TypeList,
 				Value: []ast.Variable{
-					ast.Variable{
+					{
 						Type: ast.TypeList,
 						Value: []ast.Variable{
-							ast.Variable{
+							{
 								Type:  ast.TypeString,
 								Value: "Hello",
 							},
-							ast.Variable{
+							{
 								Type:  ast.TypeString,
 								Value: "World",
 							},
 						},
 					},
-					ast.Variable{
+					{
 						Type: ast.TypeList,
 						Value: []ast.Variable{
-							ast.Variable{
+							{
 								Type:  ast.TypeString,
 								Value: "Goodbye",
 							},
-							ast.Variable{
+							{
 								Type:  ast.TypeString,
 								Value: "World",
 							},
@@ -103,11 +103,11 @@ func TestInterfaceToVariable(t *testing.T) {
 			expected: ast.Variable{
 				Type: ast.TypeMap,
 				Value: map[string]ast.Variable{
-					"Hello": ast.Variable{
+					"Hello": {
 						Type:  ast.TypeString,
 						Value: "World",
 					},
-					"Foo": ast.Variable{
+					"Foo": {
 						Type:  ast.TypeString,
 						Value: "Bar",
 					},
@@ -123,27 +123,27 @@ func TestInterfaceToVariable(t *testing.T) {
 			expected: ast.Variable{
 				Type: ast.TypeMap,
 				Value: map[string]ast.Variable{
-					"Hello": ast.Variable{
+					"Hello": {
 						Type: ast.TypeList,
 						Value: []ast.Variable{
-							ast.Variable{
+							{
 								Type:  ast.TypeString,
 								Value: "Hello",
 							},
-							ast.Variable{
+							{
 								Type:  ast.TypeString,
 								Value: "World",
 							},
 						},
 					},
-					"Goodbye": ast.Variable{
+					"Goodbye": {
 						Type: ast.TypeList,
 						Value: []ast.Variable{
-							ast.Variable{
+							{
 								Type:  ast.TypeString,
 								Value: "Goodbye",
 							},
-							ast.Variable{
+							{
 								Type:  ast.TypeString,
 								Value: "World",
 							},
@@ -170,15 +170,15 @@ func TestInterfaceToVariable(t *testing.T) {
 			expected: ast.Variable{
 				Type: ast.TypeMap,
 				Value: map[string]ast.Variable{
-					"us-west-1": ast.Variable{
+					"us-west-1": {
 						Type:  ast.TypeString,
 						Value: "ami-123456",
 					},
-					"us-west-2": ast.Variable{
+					"us-west-2": {
 						Type:  ast.TypeString,
 						Value: "ami-456789",
 					},
-					"eu-west-1": ast.Variable{
+					"eu-west-1": {
 						Type:  ast.TypeString,
 						Value: "ami-012345",
 					},
@@ -195,6 +195,191 @@ func TestInterfaceToVariable(t *testing.T) {
 
 		if !reflect.DeepEqual(output, tc.expected) {
 			t.Fatalf("%s:\nExpected: %s\n     Got: %s\n", tc.name, tc.expected, output)
+		}
+	}
+}
+
+func TestVariableToInterface(t *testing.T) {
+	testCases := []struct {
+		name     string
+		expected interface{}
+		input    ast.Variable
+	}{
+		{
+			name:     "string",
+			expected: "Hello world",
+			input: ast.Variable{
+				Type:  ast.TypeString,
+				Value: "Hello world",
+			},
+		},
+		{
+			name:     "empty list",
+			expected: []interface{}{},
+			input: ast.Variable{
+				Type:  ast.TypeList,
+				Value: []ast.Variable{},
+			},
+		},
+		{
+			name:     "int",
+			expected: "1",
+			input: ast.Variable{
+				Type:  ast.TypeString,
+				Value: "1",
+			},
+		},
+		{
+			name:     "list of strings",
+			expected: []interface{}{"Hello", "World"},
+			input: ast.Variable{
+				Type: ast.TypeList,
+				Value: []ast.Variable{
+					{
+						Type:  ast.TypeString,
+						Value: "Hello",
+					},
+					{
+						Type:  ast.TypeString,
+						Value: "World",
+					},
+				},
+			},
+		},
+		{
+			name:     "list of lists of strings",
+			expected: []interface{}{[]interface{}{"Hello", "World"}, []interface{}{"Goodbye", "World"}},
+			input: ast.Variable{
+				Type: ast.TypeList,
+				Value: []ast.Variable{
+					{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							{
+								Type:  ast.TypeString,
+								Value: "Hello",
+							},
+							{
+								Type:  ast.TypeString,
+								Value: "World",
+							},
+						},
+					},
+					{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							{
+								Type:  ast.TypeString,
+								Value: "Goodbye",
+							},
+							{
+								Type:  ast.TypeString,
+								Value: "World",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "map of string->string",
+			expected: map[string]interface{}{"Hello": "World", "Foo": "Bar"},
+			input: ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"Hello": {
+						Type:  ast.TypeString,
+						Value: "World",
+					},
+					"Foo": {
+						Type:  ast.TypeString,
+						Value: "Bar",
+					},
+				},
+			},
+		},
+		{
+			name: "map of lists of strings",
+			expected: map[string]interface{}{
+				"Hello":   []interface{}{"Hello", "World"},
+				"Goodbye": []interface{}{"Goodbye", "World"},
+			},
+			input: ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"Hello": {
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							{
+								Type:  ast.TypeString,
+								Value: "Hello",
+							},
+							{
+								Type:  ast.TypeString,
+								Value: "World",
+							},
+						},
+					},
+					"Goodbye": {
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							{
+								Type:  ast.TypeString,
+								Value: "Goodbye",
+							},
+							{
+								Type:  ast.TypeString,
+								Value: "World",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "empty map",
+			expected: map[string]interface{}{},
+			input: ast.Variable{
+				Type:  ast.TypeMap,
+				Value: map[string]ast.Variable{},
+			},
+		},
+		{
+			name: "three-element map",
+			expected: map[string]interface{}{
+				"us-west-1": "ami-123456",
+				"us-west-2": "ami-456789",
+				"eu-west-1": "ami-012345",
+			},
+			input: ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"us-west-1": {
+						Type:  ast.TypeString,
+						Value: "ami-123456",
+					},
+					"us-west-2": {
+						Type:  ast.TypeString,
+						Value: "ami-456789",
+					},
+					"eu-west-1": {
+						Type:  ast.TypeString,
+						Value: "ami-012345",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		output, err := VariableToInterface(tc.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(output, tc.expected) {
+			t.Fatalf("%s:\nExpected: %s\n     Got: %s\n", tc.name,
+				tc.expected, output)
 		}
 	}
 }

--- a/eval.go
+++ b/eval.go
@@ -63,15 +63,23 @@ func Eval(root ast.Node, config *EvalConfig) (EvaluationResult, error) {
 
 	switch outputType {
 	case ast.TypeList:
+		val, err := VariableToInterface(ast.Variable{
+			Type:  ast.TypeList,
+			Value: output,
+		})
 		return EvaluationResult{
 			Type:  TypeList,
-			Value: hilListToGoSlice(output.([]ast.Variable)),
-		}, nil
+			Value: val,
+		}, err
 	case ast.TypeMap:
+		val, err := VariableToInterface(ast.Variable{
+			Type:  ast.TypeMap,
+			Value: output,
+		})
 		return EvaluationResult{
-			Type:  TypeMap,
-			Value: hilMapToGoMap(output.(map[string]ast.Variable)),
-		}, nil
+			Type: TypeMap,
+			Value: val,
+		}, err
 	case ast.TypeString:
 		return EvaluationResult{
 			Type:  TypeString,
@@ -335,32 +343,6 @@ func (v *evalIndex) evalMapIndex(variableName string, target interface{}, key in
 	}
 
 	return value.Value, value.Type, nil
-}
-
-// hilListToGoSlice converts an ast.Variable into a []interface{}. We assume that
-// the type checking is already done since this is internal and only used in output
-// evaluation.
-func hilListToGoSlice(variable []ast.Variable) []interface{} {
-	output := make([]interface{}, len(variable))
-
-	for index, element := range variable {
-		output[index] = element.Value
-	}
-
-	return output
-}
-
-// hilMapToGoMap converts an ast.Variable into a map[string]interface{}. We assume
-// that the type checking is already done since this is internal and only used in
-// output evaluation.
-func hilMapToGoMap(variable map[string]ast.Variable) map[string]interface{} {
-	output := make(map[string]interface{})
-
-	for key, element := range variable {
-		output[key] = element.Value
-	}
-
-	return output
 }
 
 type evalOutput struct{ *ast.Output }


### PR DESCRIPTION
Previously `ast.Variable`'s were expanded only at the "top" level during evaluation. This causes a problem in Terraform when using lists or maps of other complex structures. This PR contains changes to rectify this, as well as a new VariableToInterface function which can be used outside of the package if necessary. Some older functionally similar but less elegant code is removed.

This forms part of fixing hashicorp/terraform#7143.