### PR TITLE
Test input for ast.Variable in InterfaceToVariable

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -42,6 +42,10 @@ func hilMapstructureWeakDecode(m interface{}, rawVal interface{}) error {
 }
 
 func InterfaceToVariable(input interface{}) (ast.Variable, error) {
+	if inputVariable, ok := input.(ast.Variable); ok {
+		return inputVariable, nil
+	}
+
 	var stringVal string
 	if err := hilMapstructureWeakDecode(input, &stringVal); err == nil {
 		return ast.Variable{

--- a/convert_test.go
+++ b/convert_test.go
@@ -7,6 +7,17 @@ import (
 	"github.com/hashicorp/hil/ast"
 )
 
+func TestInterfaceToVariable_variableInput(t *testing.T) {
+	_, err := InterfaceToVariable(ast.Variable{
+		Type:  ast.TypeString,
+		Value: "Hello world",
+	})
+
+	if err != nil {
+		t.Fatalf("Bad: %s", err)
+	}
+}
+
 func TestInterfaceToVariable(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
This pull request adds a check to the `InterfaceToVariable` helper to ensure that the input is not already wrapped with the HIL type annotations. If it is, the input is returned unmodified.