### PR TITLE
Nice error instead of panic for divide by zero

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -1,6 +1,7 @@
 package hil
 
 import (
+	"errors"
 	"strconv"
 
 	"github.com/hashicorp/hil/ast"
@@ -77,8 +78,16 @@ func builtinIntMath() ast.Function {
 				case ast.ArithmeticOpMul:
 					result *= arg
 				case ast.ArithmeticOpDiv:
+					if arg == 0 {
+						return nil, errors.New("divide by zero")
+					}
+
 					result /= arg
 				case ast.ArithmeticOpMod:
+					if arg == 0 {
+						return nil, errors.New("divide by zero")
+					}
+
 					result = result % arg
 				}
 			}

--- a/eval_test.go
+++ b/eval_test.go
@@ -423,11 +423,27 @@ func TestEvalInternal(t *testing.T) {
 		},
 
 		{
+			"foo ${42/0}",
+			nil,
+			true,
+			"foo ",
+			ast.TypeInvalid,
+		},
+
+		{
 			"foo ${42%4}",
 			nil,
 			false,
 			"foo 2",
 			ast.TypeString,
+		},
+
+		{
+			"foo ${42%0}",
+			nil,
+			true,
+			"foo ",
+			ast.TypeInvalid,
 		},
 
 		{


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/7701

Go panics on divide by zero which causes really bad behavior for embedding HIL. This catches it and returns a nicer error.