### PR TITLE
Add bool type

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -54,6 +54,7 @@ const (
 	TypeFloat
 	TypeList
 	TypeMap
+	TypeBool
 )
 
 func (t Type) Printable() string {
@@ -72,6 +73,8 @@ func (t Type) Printable() string {
 		return "type list"
 	case TypeMap:
 		return "type map"
+	case TypeBool:
+		return "type bool"
 	default:
 		return "unknown type"
 	}

--- a/ast/type_string.go
+++ b/ast/type_string.go
@@ -12,6 +12,7 @@ const (
 	_Type_name_4 = "TypeFloat"
 	_Type_name_5 = "TypeList"
 	_Type_name_6 = "TypeMap"
+	_Type_name_7 = "TypeBool"
 )
 
 var (
@@ -22,6 +23,7 @@ var (
 	_Type_index_4 = [...]uint8{0, 9}
 	_Type_index_5 = [...]uint8{0, 8}
 	_Type_index_6 = [...]uint8{0, 7}
+	_Type_index_7 = [...]uint8{0, 8}
 )
 
 func (i Type) String() string {
@@ -40,6 +42,8 @@ func (i Type) String() string {
 		return _Type_name_5
 	case i == 64:
 		return _Type_name_6
+	case i == 128:
+		return _Type_name_7
 	default:
 		return fmt.Sprintf("Type(%d)", i)
 	}

--- a/builtins.go
+++ b/builtins.go
@@ -18,12 +18,14 @@ func registerBuiltins(scope *ast.BasicScope) *ast.BasicScope {
 	}
 
 	// Implicit conversions
+	scope.FuncMap["__builtin_BoolToString"] = builtinBoolToString()
 	scope.FuncMap["__builtin_FloatToInt"] = builtinFloatToInt()
 	scope.FuncMap["__builtin_FloatToString"] = builtinFloatToString()
 	scope.FuncMap["__builtin_IntToFloat"] = builtinIntToFloat()
 	scope.FuncMap["__builtin_IntToString"] = builtinIntToString()
 	scope.FuncMap["__builtin_StringToInt"] = builtinStringToInt()
 	scope.FuncMap["__builtin_StringToFloat"] = builtinStringToFloat()
+	scope.FuncMap["__builtin_StringToBool"] = builtinStringToBool()
 
 	// Math operations
 	scope.FuncMap["__builtin_IntMath"] = builtinIntMath()
@@ -159,6 +161,31 @@ func builtinStringToFloat() ast.Function {
 		ReturnType: ast.TypeFloat,
 		Callback: func(args []interface{}) (interface{}, error) {
 			v, err := strconv.ParseFloat(args[0].(string), 64)
+			if err != nil {
+				return nil, err
+			}
+
+			return v, nil
+		},
+	}
+}
+
+func builtinBoolToString() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeBool},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			return strconv.FormatBool(args[0].(bool)), nil
+		},
+	}
+}
+
+func builtinStringToBool() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString},
+		ReturnType: ast.TypeBool,
+		Callback: func(args []interface{}) (interface{}, error) {
+			v, err := strconv.ParseBool(args[0].(string))
 			if err != nil {
 				return nil, err
 			}

--- a/eval.go
+++ b/eval.go
@@ -32,6 +32,7 @@ type SemanticChecker func(ast.Node) error
 //     TypeString:  string
 //     TypeList:    []interface{}
 //     TypeMap:     map[string]interface{}
+//     TypBool:     bool
 type EvaluationResult struct {
 	Type  EvalType
 	Value interface{}
@@ -72,6 +73,11 @@ func Eval(root ast.Node, config *EvalConfig) (EvaluationResult, error) {
 			Type:  TypeString,
 			Value: output,
 		}, nil
+	case ast.TypeBool:
+		return EvaluationResult{
+			Type:  TypeBool,
+			Value: output,
+		}, nil
 	default:
 		return InvalidResult, fmt.Errorf("unknown type %s as interpolation output", outputType)
 	}
@@ -97,6 +103,10 @@ func internalEval(root ast.Node, config *EvalConfig) (interface{}, ast.Type, err
 		ast.TypeString: {
 			ast.TypeInt:   "__builtin_StringToInt",
 			ast.TypeFloat: "__builtin_StringToFloat",
+			ast.TypeBool:  "__builtin_StringToBool",
+		},
+		ast.TypeBool: {
+			ast.TypeString: "__builtin_BoolToString",
 		},
 	}
 

--- a/eval_type.go
+++ b/eval_type.go
@@ -11,4 +11,5 @@ const (
 	TypeString  EvalType = 1 << iota
 	TypeList
 	TypeMap
+	TypeBool
 )

--- a/evaltype_string.go
+++ b/evaltype_string.go
@@ -9,6 +9,7 @@ const (
 	_EvalType_name_1 = "TypeString"
 	_EvalType_name_2 = "TypeList"
 	_EvalType_name_3 = "TypeMap"
+	_EvalType_name_4 = "TypeBool"
 )
 
 var (
@@ -16,6 +17,7 @@ var (
 	_EvalType_index_1 = [...]uint8{0, 10}
 	_EvalType_index_2 = [...]uint8{0, 8}
 	_EvalType_index_3 = [...]uint8{0, 7}
+	_EvalType_index_4 = [...]uint8{0, 8}
 )
 
 func (i EvalType) String() string {
@@ -28,6 +30,8 @@ func (i EvalType) String() string {
 		return _EvalType_name_2
 	case i == 8:
 		return _EvalType_name_3
+	case i == 16:
+		return _EvalType_name_4
 	default:
 		return fmt.Sprintf("EvalType(%d)", i)
 	}

--- a/lang.y
+++ b/lang.y
@@ -25,7 +25,7 @@ import (
 %token  <str> PAREN_LEFT PAREN_RIGHT COMMA
 %token  <str> SQUARE_BRACKET_LEFT SQUARE_BRACKET_RIGHT
 
-%token <token> ARITH_OP IDENTIFIER INTEGER FLOAT STRING
+%token <token> ARITH_OP IDENTIFIER INTEGER FLOAT BOOL STRING
 
 %type <node> expr interpolation literal literalModeTop literalModeValue
 %type <nodeList> args
@@ -122,6 +122,14 @@ expr:
         $$ = &ast.LiteralNode{
             Value: $1.Value.(float64),
             Typex:  ast.TypeFloat,
+            Posx:  $1.Pos,
+        }
+    }
+|   BOOL
+    {
+        $$ = &ast.LiteralNode{
+            Value: $1.Value.(bool),
+            Typex:  ast.TypeBool,
             Posx:  $1.Pos,
         }
     }

--- a/lex.go
+++ b/lex.go
@@ -230,6 +230,16 @@ func (x *parserLex) lexId(yylval *parserSymType) int {
 		last = c
 	}
 
+	if b.String() == "true" {
+		yylval.token = &parserToken{Value: true}
+		return BOOL
+	}
+
+	if b.String() == "false" {
+		yylval.token = &parserToken{Value: false}
+		return BOOL
+	}
+
 	yylval.token = &parserToken{Value: b.String()}
 	return IDENTIFIER
 }

--- a/lex_test.go
+++ b/lex_test.go
@@ -87,6 +87,13 @@ func TestLex(t *testing.T) {
 		},
 
 		{
+			"${bar(true)}",
+			[]int{PROGRAM_BRACKET_LEFT,
+				IDENTIFIER, PAREN_LEFT, BOOL, PAREN_RIGHT,
+				PROGRAM_BRACKET_RIGHT, lexEOF},
+		},
+
+		{
 			"${bar(inner(baz))}",
 			[]int{PROGRAM_BRACKET_LEFT,
 				IDENTIFIER, PAREN_LEFT,

--- a/parse_test.go
+++ b/parse_test.go
@@ -153,6 +153,26 @@ func TestParse(t *testing.T) {
 		},
 
 		{
+			"foo ${true}",
+			false,
+			&ast.Output{
+				Posx: ast.Pos{Column: 1, Line: 1},
+				Exprs: []ast.Node{
+					&ast.LiteralNode{
+						Value: "foo ",
+						Typex: ast.TypeString,
+						Posx:  ast.Pos{Column: 1, Line: 1},
+					},
+					&ast.LiteralNode{
+						Value: true,
+						Typex: ast.TypeBool,
+						Posx:  ast.Pos{Column: 7, Line: 1},
+					},
+				},
+			},
+		},
+
+		{
 			"foo ${42+1}",
 			false,
 			&ast.Output{
@@ -430,7 +450,7 @@ func TestParse(t *testing.T) {
 			t.Fatalf("Error: %s\n\nInput: %s", err, tc.Input)
 		}
 		if !reflect.DeepEqual(actual, tc.Result) {
-			t.Fatalf("Bad: %#v\n\nInput: %s", actual, tc.Input)
+			t.Fatalf("\nBad : %#v\nHave: %#v\n\nInput: %s", tc.Result, actual, tc.Input)
 		}
 	}
 }

--- a/y.go
+++ b/y.go
@@ -32,7 +32,8 @@ const ARITH_OP = 57355
 const IDENTIFIER = 57356
 const INTEGER = 57357
 const FLOAT = 57358
-const STRING = 57359
+const BOOL = 57359
+const STRING = 57360
 
 var parserToknames = [...]string{
 	"$end",
@@ -51,6 +52,7 @@ var parserToknames = [...]string{
 	"IDENTIFIER",
 	"INTEGER",
 	"FLOAT",
+	"BOOL",
 	"STRING",
 }
 var parserStatenames = [...]string{}
@@ -59,7 +61,7 @@ const parserEofCode = 1
 const parserErrCode = 2
 const parserInitialStackSize = 16
 
-//line lang.y:200
+//line lang.y:208
 
 //line yacctab:1
 var parserExca = [...]int{
@@ -68,57 +70,57 @@ var parserExca = [...]int{
 	-2, 0,
 }
 
-const parserNprod = 21
+const parserNprod = 22
 const parserPrivate = 57344
 
 var parserTokenNames []string
 var parserStates []string
 
-const parserLast = 37
+const parserLast = 39
 
 var parserAct = [...]int{
 
-	9, 7, 29, 17, 23, 16, 17, 3, 17, 20,
-	8, 18, 21, 17, 6, 19, 27, 28, 22, 8,
-	1, 25, 26, 7, 11, 2, 24, 10, 4, 30,
-	5, 0, 14, 15, 12, 13, 6,
+	9, 7, 30, 18, 24, 17, 18, 21, 18, 3,
+	22, 19, 8, 18, 1, 6, 20, 28, 29, 23,
+	25, 8, 26, 27, 7, 11, 2, 4, 10, 5,
+	31, 0, 0, 15, 16, 12, 13, 14, 6,
 }
 var parserPact = [...]int{
 
-	-3, -1000, -3, -1000, -1000, -1000, -1000, 19, -1000, 0,
-	19, -3, -1000, -1000, 19, 1, -1000, 19, -5, -1000,
-	19, 19, -1000, -1000, 7, -7, -10, -1000, 19, -1000,
-	-7,
+	-3, -1000, -3, -1000, -1000, -1000, -1000, 20, -1000, 0,
+	20, -3, -1000, -1000, -1000, 20, -1, -1000, 20, -5,
+	-1000, 20, 20, -1000, -1000, 8, -7, -10, -1000, 20,
+	-1000, -7,
 }
 var parserPgo = [...]int{
 
-	0, 0, 30, 28, 24, 7, 26, 20,
+	0, 0, 29, 27, 25, 9, 20, 14,
 }
 var parserR1 = [...]int{
 
 	0, 7, 7, 4, 4, 5, 5, 2, 1, 1,
-	1, 1, 1, 1, 1, 1, 1, 6, 6, 6,
-	3,
+	1, 1, 1, 1, 1, 1, 1, 1, 6, 6,
+	6, 3,
 }
 var parserR2 = [...]int{
 
 	0, 0, 1, 1, 2, 1, 1, 3, 3, 1,
-	1, 1, 2, 3, 1, 4, 4, 0, 3, 1,
-	1,
+	1, 1, 1, 2, 3, 1, 4, 4, 0, 3,
+	1, 1,
 }
 var parserChk = [...]int{
 
-	-1000, -7, -4, -5, -3, -2, 17, 4, -5, -1,
-	8, -4, 15, 16, 13, 14, 5, 13, -1, -1,
-	8, 11, -1, 9, -6, -1, -1, 9, 10, 12,
-	-1,
+	-1000, -7, -4, -5, -3, -2, 18, 4, -5, -1,
+	8, -4, 15, 16, 17, 13, 14, 5, 13, -1,
+	-1, 8, 11, -1, 9, -6, -1, -1, 9, 10,
+	12, -1,
 }
 var parserDef = [...]int{
 
-	1, -2, 2, 3, 5, 6, 20, 0, 4, 0,
-	0, 9, 10, 11, 0, 14, 7, 0, 0, 12,
-	17, 0, 13, 8, 0, 19, 0, 15, 0, 16,
-	18,
+	1, -2, 2, 3, 5, 6, 21, 0, 4, 0,
+	0, 9, 10, 11, 12, 0, 15, 7, 0, 0,
+	13, 18, 0, 14, 8, 0, 20, 0, 16, 0,
+	17, 19,
 }
 var parserTok1 = [...]int{
 
@@ -127,7 +129,7 @@ var parserTok1 = [...]int{
 var parserTok2 = [...]int{
 
 	2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
-	12, 13, 14, 15, 16, 17,
+	12, 13, 14, 15, 16, 17, 18,
 }
 var parserTok3 = [...]int{
 	0,
@@ -576,8 +578,18 @@ parserdefault:
 			}
 		}
 	case 12:
-		parserDollar = parserS[parserpt-2 : parserpt+1]
+		parserDollar = parserS[parserpt-1 : parserpt+1]
 		//line lang.y:129
+		{
+			parserVAL.node = &ast.LiteralNode{
+				Value: parserDollar[1].token.Value.(bool),
+				Typex: ast.TypeBool,
+				Posx:  parserDollar[1].token.Pos,
+			}
+		}
+	case 13:
+		parserDollar = parserS[parserpt-2 : parserpt+1]
+		//line lang.y:137
 		{
 			// This is REALLY jank. We assume that a singular ARITH_OP
 			// means 0 ARITH_OP expr, which... is weird. We don't want to
@@ -598,9 +610,9 @@ parserdefault:
 				Posx: parserDollar[2].node.Pos(),
 			}
 		}
-	case 13:
+	case 14:
 		parserDollar = parserS[parserpt-3 : parserpt+1]
-		//line lang.y:150
+		//line lang.y:158
 		{
 			parserVAL.node = &ast.Arithmetic{
 				Op:    parserDollar[2].token.Value.(ast.ArithmeticOp),
@@ -608,21 +620,21 @@ parserdefault:
 				Posx:  parserDollar[1].node.Pos(),
 			}
 		}
-	case 14:
+	case 15:
 		parserDollar = parserS[parserpt-1 : parserpt+1]
-		//line lang.y:158
+		//line lang.y:166
 		{
 			parserVAL.node = &ast.VariableAccess{Name: parserDollar[1].token.Value.(string), Posx: parserDollar[1].token.Pos}
 		}
-	case 15:
+	case 16:
 		parserDollar = parserS[parserpt-4 : parserpt+1]
-		//line lang.y:162
+		//line lang.y:170
 		{
 			parserVAL.node = &ast.Call{Func: parserDollar[1].token.Value.(string), Args: parserDollar[3].nodeList, Posx: parserDollar[1].token.Pos}
 		}
-	case 16:
+	case 17:
 		parserDollar = parserS[parserpt-4 : parserpt+1]
-		//line lang.y:166
+		//line lang.y:174
 		{
 			parserVAL.node = &ast.Index{
 				Target: &ast.VariableAccess{
@@ -633,27 +645,27 @@ parserdefault:
 				Posx: parserDollar[1].token.Pos,
 			}
 		}
-	case 17:
+	case 18:
 		parserDollar = parserS[parserpt-0 : parserpt+1]
-		//line lang.y:178
+		//line lang.y:186
 		{
 			parserVAL.nodeList = nil
 		}
-	case 18:
+	case 19:
 		parserDollar = parserS[parserpt-3 : parserpt+1]
-		//line lang.y:182
+		//line lang.y:190
 		{
 			parserVAL.nodeList = append(parserDollar[1].nodeList, parserDollar[3].node)
 		}
-	case 19:
+	case 20:
 		parserDollar = parserS[parserpt-1 : parserpt+1]
-		//line lang.y:186
+		//line lang.y:194
 		{
 			parserVAL.nodeList = append(parserVAL.nodeList, parserDollar[1].node)
 		}
-	case 20:
+	case 21:
 		parserDollar = parserS[parserpt-1 : parserpt+1]
-		//line lang.y:192
+		//line lang.y:200
 		{
 			parserVAL.node = &ast.LiteralNode{
 				Value: parserDollar[1].token.Value.(string),

--- a/y.output
+++ b/y.output
@@ -51,9 +51,9 @@ state 5
 
 
 state 6
-	literal:  STRING.    (20)
+	literal:  STRING.    (21)
 
-	.  reduce 20 (src line 190)
+	.  reduce 21 (src line 198)
 
 
 state 7
@@ -61,10 +61,11 @@ state 7
 
 	PROGRAM_BRACKET_LEFT  shift 7
 	PAREN_LEFT  shift 10
-	ARITH_OP  shift 14
-	IDENTIFIER  shift 15
+	ARITH_OP  shift 15
+	IDENTIFIER  shift 16
 	INTEGER  shift 12
 	FLOAT  shift 13
+	BOOL  shift 14
 	STRING  shift 6
 	.  error
 
@@ -84,8 +85,8 @@ state 9
 	interpolation:  PROGRAM_BRACKET_LEFT expr.PROGRAM_BRACKET_RIGHT 
 	expr:  expr.ARITH_OP expr 
 
-	PROGRAM_BRACKET_RIGHT  shift 16
-	ARITH_OP  shift 17
+	PROGRAM_BRACKET_RIGHT  shift 17
+	ARITH_OP  shift 18
 	.  error
 
 
@@ -94,14 +95,15 @@ state 10
 
 	PROGRAM_BRACKET_LEFT  shift 7
 	PAREN_LEFT  shift 10
-	ARITH_OP  shift 14
-	IDENTIFIER  shift 15
+	ARITH_OP  shift 15
+	IDENTIFIER  shift 16
 	INTEGER  shift 12
 	FLOAT  shift 13
+	BOOL  shift 14
 	STRING  shift 6
 	.  error
 
-	expr  goto 18
+	expr  goto 19
 	interpolation  goto 5
 	literal  goto 4
 	literalModeTop  goto 11
@@ -132,197 +134,208 @@ state 13
 
 
 state 14
+	expr:  BOOL.    (12)
+
+	.  reduce 12 (src line 128)
+
+
+state 15
 	expr:  ARITH_OP.expr 
 
 	PROGRAM_BRACKET_LEFT  shift 7
 	PAREN_LEFT  shift 10
-	ARITH_OP  shift 14
-	IDENTIFIER  shift 15
+	ARITH_OP  shift 15
+	IDENTIFIER  shift 16
 	INTEGER  shift 12
 	FLOAT  shift 13
+	BOOL  shift 14
 	STRING  shift 6
 	.  error
 
-	expr  goto 19
+	expr  goto 20
 	interpolation  goto 5
 	literal  goto 4
 	literalModeTop  goto 11
 	literalModeValue  goto 3
 
-state 15
-	expr:  IDENTIFIER.    (14)
+state 16
+	expr:  IDENTIFIER.    (15)
 	expr:  IDENTIFIER.PAREN_LEFT args PAREN_RIGHT 
 	expr:  IDENTIFIER.SQUARE_BRACKET_LEFT expr SQUARE_BRACKET_RIGHT 
 
-	PAREN_LEFT  shift 20
-	SQUARE_BRACKET_LEFT  shift 21
-	.  reduce 14 (src line 157)
+	PAREN_LEFT  shift 21
+	SQUARE_BRACKET_LEFT  shift 22
+	.  reduce 15 (src line 165)
 
 
-state 16
+state 17
 	interpolation:  PROGRAM_BRACKET_LEFT expr PROGRAM_BRACKET_RIGHT.    (7)
 
 	.  reduce 7 (src line 97)
 
 
-state 17
+state 18
 	expr:  expr ARITH_OP.expr 
 
 	PROGRAM_BRACKET_LEFT  shift 7
 	PAREN_LEFT  shift 10
-	ARITH_OP  shift 14
-	IDENTIFIER  shift 15
+	ARITH_OP  shift 15
+	IDENTIFIER  shift 16
 	INTEGER  shift 12
 	FLOAT  shift 13
+	BOOL  shift 14
 	STRING  shift 6
 	.  error
 
-	expr  goto 22
+	expr  goto 23
 	interpolation  goto 5
 	literal  goto 4
 	literalModeTop  goto 11
 	literalModeValue  goto 3
 
-state 18
+state 19
 	expr:  PAREN_LEFT expr.PAREN_RIGHT 
 	expr:  expr.ARITH_OP expr 
 
-	PAREN_RIGHT  shift 23
-	ARITH_OP  shift 17
+	PAREN_RIGHT  shift 24
+	ARITH_OP  shift 18
 	.  error
-
-
-state 19
-	expr:  ARITH_OP expr.    (12)
-	expr:  expr.ARITH_OP expr 
-
-	.  reduce 12 (src line 128)
 
 
 state 20
-	expr:  IDENTIFIER PAREN_LEFT.args PAREN_RIGHT 
-	args: .    (17)
+	expr:  ARITH_OP expr.    (13)
+	expr:  expr.ARITH_OP expr 
 
-	PROGRAM_BRACKET_LEFT  shift 7
-	PAREN_LEFT  shift 10
-	ARITH_OP  shift 14
-	IDENTIFIER  shift 15
-	INTEGER  shift 12
-	FLOAT  shift 13
-	STRING  shift 6
-	.  reduce 17 (src line 177)
+	.  reduce 13 (src line 136)
 
-	expr  goto 25
-	interpolation  goto 5
-	literal  goto 4
-	literalModeTop  goto 11
-	literalModeValue  goto 3
-	args  goto 24
 
 state 21
-	expr:  IDENTIFIER SQUARE_BRACKET_LEFT.expr SQUARE_BRACKET_RIGHT 
+	expr:  IDENTIFIER PAREN_LEFT.args PAREN_RIGHT 
+	args: .    (18)
 
 	PROGRAM_BRACKET_LEFT  shift 7
 	PAREN_LEFT  shift 10
-	ARITH_OP  shift 14
-	IDENTIFIER  shift 15
+	ARITH_OP  shift 15
+	IDENTIFIER  shift 16
 	INTEGER  shift 12
 	FLOAT  shift 13
+	BOOL  shift 14
 	STRING  shift 6
-	.  error
+	.  reduce 18 (src line 185)
 
 	expr  goto 26
 	interpolation  goto 5
 	literal  goto 4
 	literalModeTop  goto 11
 	literalModeValue  goto 3
+	args  goto 25
 
 state 22
-	expr:  expr.ARITH_OP expr 
-	expr:  expr ARITH_OP expr.    (13)
-
-	.  reduce 13 (src line 149)
-
-
-state 23
-	expr:  PAREN_LEFT expr PAREN_RIGHT.    (8)
-
-	.  reduce 8 (src line 103)
-
-
-state 24
-	expr:  IDENTIFIER PAREN_LEFT args.PAREN_RIGHT 
-	args:  args.COMMA expr 
-
-	PAREN_RIGHT  shift 27
-	COMMA  shift 28
-	.  error
-
-
-state 25
-	expr:  expr.ARITH_OP expr 
-	args:  expr.    (19)
-
-	ARITH_OP  shift 17
-	.  reduce 19 (src line 185)
-
-
-state 26
-	expr:  expr.ARITH_OP expr 
-	expr:  IDENTIFIER SQUARE_BRACKET_LEFT expr.SQUARE_BRACKET_RIGHT 
-
-	SQUARE_BRACKET_RIGHT  shift 29
-	ARITH_OP  shift 17
-	.  error
-
-
-state 27
-	expr:  IDENTIFIER PAREN_LEFT args PAREN_RIGHT.    (15)
-
-	.  reduce 15 (src line 161)
-
-
-state 28
-	args:  args COMMA.expr 
+	expr:  IDENTIFIER SQUARE_BRACKET_LEFT.expr SQUARE_BRACKET_RIGHT 
 
 	PROGRAM_BRACKET_LEFT  shift 7
 	PAREN_LEFT  shift 10
-	ARITH_OP  shift 14
-	IDENTIFIER  shift 15
+	ARITH_OP  shift 15
+	IDENTIFIER  shift 16
 	INTEGER  shift 12
 	FLOAT  shift 13
+	BOOL  shift 14
 	STRING  shift 6
 	.  error
 
-	expr  goto 30
+	expr  goto 27
 	interpolation  goto 5
 	literal  goto 4
 	literalModeTop  goto 11
 	literalModeValue  goto 3
 
+state 23
+	expr:  expr.ARITH_OP expr 
+	expr:  expr ARITH_OP expr.    (14)
+
+	.  reduce 14 (src line 157)
+
+
+state 24
+	expr:  PAREN_LEFT expr PAREN_RIGHT.    (8)
+
+	.  reduce 8 (src line 103)
+
+
+state 25
+	expr:  IDENTIFIER PAREN_LEFT args.PAREN_RIGHT 
+	args:  args.COMMA expr 
+
+	PAREN_RIGHT  shift 28
+	COMMA  shift 29
+	.  error
+
+
+state 26
+	expr:  expr.ARITH_OP expr 
+	args:  expr.    (20)
+
+	ARITH_OP  shift 18
+	.  reduce 20 (src line 193)
+
+
+state 27
+	expr:  expr.ARITH_OP expr 
+	expr:  IDENTIFIER SQUARE_BRACKET_LEFT expr.SQUARE_BRACKET_RIGHT 
+
+	SQUARE_BRACKET_RIGHT  shift 30
+	ARITH_OP  shift 18
+	.  error
+
+
+state 28
+	expr:  IDENTIFIER PAREN_LEFT args PAREN_RIGHT.    (16)
+
+	.  reduce 16 (src line 169)
+
+
 state 29
-	expr:  IDENTIFIER SQUARE_BRACKET_LEFT expr SQUARE_BRACKET_RIGHT.    (16)
+	args:  args COMMA.expr 
 
-	.  reduce 16 (src line 165)
+	PROGRAM_BRACKET_LEFT  shift 7
+	PAREN_LEFT  shift 10
+	ARITH_OP  shift 15
+	IDENTIFIER  shift 16
+	INTEGER  shift 12
+	FLOAT  shift 13
+	BOOL  shift 14
+	STRING  shift 6
+	.  error
 
+	expr  goto 31
+	interpolation  goto 5
+	literal  goto 4
+	literalModeTop  goto 11
+	literalModeValue  goto 3
 
 state 30
+	expr:  IDENTIFIER SQUARE_BRACKET_LEFT expr SQUARE_BRACKET_RIGHT.    (17)
+
+	.  reduce 17 (src line 173)
+
+
+state 31
 	expr:  expr.ARITH_OP expr 
-	args:  args COMMA expr.    (18)
+	args:  args COMMA expr.    (19)
 
-	ARITH_OP  shift 17
-	.  reduce 18 (src line 181)
+	ARITH_OP  shift 18
+	.  reduce 19 (src line 189)
 
 
-17 terminals, 8 nonterminals
-21 grammar rules, 31/2000 states
+18 terminals, 8 nonterminals
+22 grammar rules, 32/2000 states
 0 shift/reduce, 0 reduce/reduce conflicts reported
 57 working sets used
 memory: parser 45/30000
-26 extra closures
-67 shift entries, 1 exceptions
+27 extra closures
+74 shift entries, 1 exceptions
 16 goto entries
 31 entries saved by goto default
-Optimizer space used: output 37/30000
-37 table entries, 1 zero
-maximum spread: 17, maximum offset: 28
+Optimizer space used: output 39/30000
+39 table entries, 2 zero
+maximum spread: 18, maximum offset: 29


### PR DESCRIPTION
This PR adds a new `TypeBool`. That allows us to write functions that
returns true or false. I think this is an important step for
https://github.com/hashicorp/terraform/issues/1604 as well

Here is an example `ast.Function` called `equal` that compares two
values and returns true or false (compiles with this PR).

https://play.golang.org/p/JpJ7GzA454

I've tried to check whether this breaks something, but right now it
passes all tests. Unfortunately I don't like the yacc parser, so it's
hard to understand it. Let me know if this is not suitable or if
something is wrong here.
