### PR TITLE
Indexes may require further interpolation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 sudo: false
 language: go
-go: 1.5
+go: 1.7

--- a/ast/index.go
+++ b/ast/index.go
@@ -13,6 +13,11 @@ type Index struct {
 }
 
 func (n *Index) Accept(v Visitor) Node {
+	// the Key may have further interpolations
+	switch n.Key.(type) {
+	case *Call, *VariableAccess:
+		n.Key = n.Key.Accept(v)
+	}
 	return v(n)
 }
 

--- a/eval_test.go
+++ b/eval_test.go
@@ -1,6 +1,7 @@
 package hil
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -344,22 +345,24 @@ func TestEval(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
-		node, err := Parse(tc.Input)
-		if err != nil {
-			t.Fatalf("Error: %s\n\nInput: %s", err, tc.Input)
-		}
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.Input), func(t *testing.T) {
+			node, err := Parse(tc.Input)
+			if err != nil {
+				t.Fatalf("Error: %s\n\nInput: %s", err, tc.Input)
+			}
 
-		result, err := Eval(node, &EvalConfig{GlobalScope: tc.Scope})
-		if err != nil != tc.Error {
-			t.Fatalf("Error: %s\n\nInput: %s", err, tc.Input)
-		}
-		if tc.ResultType != TypeInvalid && result.Type != tc.ResultType {
-			t.Fatalf("Bad: %s\n\nInput: %s", result.Type, tc.Input)
-		}
-		if !reflect.DeepEqual(result.Value, tc.Result) {
-			t.Fatalf("\n     Bad: %#v\nExpected: %#v\n\nInput: %s", result.Value, tc.Result, tc.Input)
-		}
+			result, err := Eval(node, &EvalConfig{GlobalScope: tc.Scope})
+			if err != nil != tc.Error {
+				t.Fatalf("Error: %s\n\nInput: %s", err, tc.Input)
+			}
+			if tc.ResultType != TypeInvalid && result.Type != tc.ResultType {
+				t.Fatalf("Bad: %s\n\nInput: %s", result.Type, tc.Input)
+			}
+			if !reflect.DeepEqual(result.Value, tc.Result) {
+				t.Fatalf("\n     Bad: %#v\nExpected: %#v\n\nInput: %s", result.Value, tc.Result, tc.Input)
+			}
+		})
 	}
 }
 
@@ -1196,21 +1199,23 @@ func TestEvalInternal(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
-		node, err := Parse(tc.Input)
-		if err != nil {
-			t.Fatalf("Error: %s\n\nInput: %s", err, tc.Input)
-		}
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.Input), func(t *testing.T) {
+			node, err := Parse(tc.Input)
+			if err != nil {
+				t.Fatalf("Error: %s\n\nInput: %s", err, tc.Input)
+			}
 
-		out, outType, err := internalEval(node, &EvalConfig{GlobalScope: tc.Scope})
-		if err != nil != tc.Error {
-			t.Fatalf("Error: %s\n\nInput: %s", err, tc.Input)
-		}
-		if tc.ResultType != ast.TypeInvalid && outType != tc.ResultType {
-			t.Fatalf("Bad: %s\n\nInput: %s", outType, tc.Input)
-		}
-		if !reflect.DeepEqual(out, tc.Result) {
-			t.Fatalf("Bad: %#v\n\nInput: %s", out, tc.Input)
-		}
+			out, outType, err := internalEval(node, &EvalConfig{GlobalScope: tc.Scope})
+			if err != nil != tc.Error {
+				t.Fatalf("Error: %s\n\nInput: %s", err, tc.Input)
+			}
+			if tc.ResultType != ast.TypeInvalid && outType != tc.ResultType {
+				t.Fatalf("Bad: %s\n\nInput: %s", outType, tc.Input)
+			}
+			if !reflect.DeepEqual(out, tc.Result) {
+				t.Fatalf("Bad: %#v\n\nInput: %s", out, tc.Input)
+			}
+		})
 	}
 }

--- a/eval_test.go
+++ b/eval_test.go
@@ -3,6 +3,7 @@ package hil
 import (
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/hil/ast"
@@ -308,6 +309,38 @@ func TestEval(t *testing.T) {
 				"World",
 			},
 			TypeList,
+		},
+		{
+			`${foo[upper(bar)]}`,
+			&ast.BasicScope{
+				FuncMap: map[string]ast.Function{
+					"upper": ast.Function{
+						ArgTypes:   []ast.Type{ast.TypeString},
+						ReturnType: ast.TypeString,
+						Callback: func(args []interface{}) (interface{}, error) {
+							return strings.ToUpper(args[0].(string)), nil
+						},
+					},
+				},
+				VarMap: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeMap,
+						Value: map[string]ast.Variable{
+							"KEY": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "value",
+							},
+						},
+					},
+					"bar": ast.Variable{
+						Value: "key",
+						Type:  ast.TypeString,
+					},
+				},
+			},
+			false,
+			"value",
+			TypeString,
 		},
 	}
 


### PR DESCRIPTION
Functions nested in map indexes didn't have an argument stack, because
the index node hadn't been visited. Make sure we call Accept on the
index Key when it could be interpolated. We don't call it
unconditionally, because list indexes are assumed not be be pre Eval'ed.

Fixes https://github.com/hashicorp/terraform/issues/9282