### PR TITLE
Support implicit conversion for list/map index key

### DIFF
--- a/check_types.go
+++ b/check_types.go
@@ -325,8 +325,11 @@ func (tc *typeCheckIndex) TypeCheck(v *TypeCheck) (ast.Node, error) {
 	switch targetType {
 	case ast.TypeList:
 		if keyType != ast.TypeInt {
-			return nil, fmt.Errorf(
-				"key of an index must be an int, was %s", keyType)
+			tc.n.Key = v.ImplicitConversion(keyType, ast.TypeInt, tc.n.Key)
+			if tc.n.Key == nil {
+				return nil, fmt.Errorf(
+					"key of an index must be an int, was %s", keyType)
+			}
 		}
 
 		valType, err := ast.VariableListElementTypesAreHomogenous(
@@ -339,8 +342,11 @@ func (tc *typeCheckIndex) TypeCheck(v *TypeCheck) (ast.Node, error) {
 		return tc.n, nil
 	case ast.TypeMap:
 		if keyType != ast.TypeString {
-			return nil, fmt.Errorf(
-				"key of an index must be a string, was %s", keyType)
+			tc.n.Key = v.ImplicitConversion(keyType, ast.TypeString, tc.n.Key)
+			if tc.n.Key == nil {
+				return nil, fmt.Errorf(
+					"key of an index must be a string, was %s", keyType)
+			}
 		}
 
 		valType, err := ast.VariableMapValueTypesAreHomogenous(

--- a/eval_test.go
+++ b/eval_test.go
@@ -83,6 +83,29 @@ func TestEval(t *testing.T) {
 			TypeString,
 		},
 		{
+			`${var.alist["1"]}`,
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"var.alist": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "Hello",
+							},
+							ast.Variable{
+								Type:  ast.TypeString,
+								Value: "World",
+							},
+						},
+					},
+				},
+			},
+			false,
+			"World",
+			TypeString,
+		},
+		{
 			"${var.alist[1]} ${var.alist[0]}",
 			&ast.BasicScope{
 				VarMap: map[string]ast.Variable{
@@ -189,6 +212,25 @@ func TestEval(t *testing.T) {
 								Value: "hello",
 							},
 							"bar": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "world",
+							},
+						},
+					},
+				},
+			},
+			false,
+			"world",
+			TypeString,
+		},
+		{
+			`${foo[3]}`,
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeMap,
+						Value: map[string]ast.Variable{
+							"3": ast.Variable{
 								Type:  ast.TypeString,
 								Value: "world",
 							},
@@ -678,30 +720,6 @@ func TestEvalInternal(t *testing.T) {
 			false,
 			"foo foobar",
 			ast.TypeString,
-		},
-
-		{
-			`${foo["bar"]}`,
-			&ast.BasicScope{
-				VarMap: map[string]ast.Variable{
-					"foo": ast.Variable{
-						Type: ast.TypeList,
-						Value: []ast.Variable{
-							ast.Variable{
-								Type:  ast.TypeString,
-								Value: "hello",
-							},
-							ast.Variable{
-								Type:  ast.TypeString,
-								Value: "world",
-							},
-						},
-					},
-				},
-			},
-			true,
-			nil,
-			ast.TypeInvalid,
 		},
 
 		{


### PR DESCRIPTION
HIL is a bit PHP-esque in that it does implicit string to number and
vice versa conversion where possible. For example `"2" - 1` equates to
1. This was a conscious decision made since without it, there ended up
being a LOT of explicit type conversion necessary since things like
counts in Terraform were/are strings.

This PR extends implicits to list and map index operations, allowing
variables that are potentially strings to be used as indexes without
type conversion operations (which don't exist right now, so you'd have
to do weird math tricks).