### PR TITLE
TypeUnknown for "unknown" values

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -54,6 +54,13 @@ const (
 	TypeFloat
 	TypeList
 	TypeMap
+
+	// This is a special type used by Terraform to mark "unknown" values.
+	// It is impossible for this type to be introduced into your HIL programs
+	// unless you explicitly set a variable to this value. In that case,
+	// any operation including the variable will return "TypeUnknown" as the
+	// type.
+	TypeUnknown
 )
 
 func (t Type) Printable() string {
@@ -72,6 +79,8 @@ func (t Type) Printable() string {
 		return "type list"
 	case TypeMap:
 		return "type map"
+	case TypeUnknown:
+		return "type unknown"
 	default:
 		return "unknown type"
 	}

--- a/ast/unknown.go
+++ b/ast/unknown.go
@@ -1,0 +1,30 @@
+package ast
+
+// IsUnknown reports whether a variable is unknown or contains any value
+// that is unknown. This will recurse into lists and maps and so on.
+func IsUnknown(v Variable) bool {
+	// If it is unknown itself, return true
+	if v.Type == TypeUnknown {
+		return true
+	}
+
+	// If it is a container type, check the values
+	switch v.Type {
+	case TypeList:
+		for _, el := range v.Value.([]Variable) {
+			if IsUnknown(el) {
+				return true
+			}
+		}
+	case TypeMap:
+		for _, el := range v.Value.(map[string]Variable) {
+			if IsUnknown(el) {
+				return true
+			}
+		}
+	default:
+	}
+
+	// Not a container type or survive the above checks
+	return false
+}

--- a/ast/variables_helper.go
+++ b/ast/variables_helper.go
@@ -5,6 +5,11 @@ import "fmt"
 func VariableListElementTypesAreHomogenous(variableName string, list []Variable) (Type, error) {
 	listTypes := make(map[Type]struct{})
 	for _, v := range list {
+		// Allow unknown
+		if v.Type == TypeUnknown {
+			continue
+		}
+
 		if _, ok := listTypes[v.Type]; ok {
 			continue
 		}
@@ -25,9 +30,15 @@ func VariableListElementTypesAreHomogenous(variableName string, list []Variable)
 func VariableMapValueTypesAreHomogenous(variableName string, vmap map[string]Variable) (Type, error) {
 	valueTypes := make(map[Type]struct{})
 	for _, v := range vmap {
+		// Allow unknown
+		if v.Type == TypeUnknown {
+			continue
+		}
+
 		if _, ok := valueTypes[v.Type]; ok {
 			continue
 		}
+
 		valueTypes[v.Type] = struct{}{}
 	}
 

--- a/check_types_test.go
+++ b/check_types_test.go
@@ -308,6 +308,27 @@ func TestTypeCheck_implicit(t *testing.T) {
 		},
 
 		{
+			"${foo[1]}",
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeList,
+						Value: []ast.Variable{
+							ast.Variable{
+								Type:  ast.TypeInt,
+								Value: 42,
+							},
+							ast.Variable{
+								Type: ast.TypeUnknown,
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
+
+		{
 			`${foo[bar[var.keyint]]}`,
 			&ast.BasicScope{
 				VarMap: map[string]ast.Variable{

--- a/convert.go
+++ b/convert.go
@@ -8,6 +8,11 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+// UnknownValue is a sentinel value that can be used to denote
+// that a value of a variable (or map element, list element, etc.)
+// is unknown. This will always have the type ast.TypeUnknown.
+const UnknownValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
+
 var hilMapstructureDecodeHookSlice []interface{}
 var hilMapstructureDecodeHookStringSlice []string
 var hilMapstructureDecodeHookMap map[string]interface{}
@@ -48,6 +53,12 @@ func InterfaceToVariable(input interface{}) (ast.Variable, error) {
 
 	var stringVal string
 	if err := hilMapstructureWeakDecode(input, &stringVal); err == nil {
+		// Special case the unknown value to turn into "unknown"
+		if stringVal == UnknownValue {
+			return ast.Variable{Type: ast.TypeUnknown}, nil
+		}
+
+		// Otherwise return the string value
 		return ast.Variable{
 			Type:  ast.TypeString,
 			Value: stringVal,

--- a/convert_test.go
+++ b/convert_test.go
@@ -109,6 +109,22 @@ func TestInterfaceToVariable(t *testing.T) {
 			},
 		},
 		{
+			name:  "list with unknown",
+			input: []string{"Hello", UnknownValue},
+			expected: ast.Variable{
+				Type: ast.TypeList,
+				Value: []ast.Variable{
+					{
+						Type:  ast.TypeString,
+						Value: "Hello",
+					},
+					{
+						Type: ast.TypeUnknown,
+					},
+				},
+			},
+		},
+		{
 			name:  "map of string->string",
 			input: map[string]string{"Hello": "World", "Foo": "Bar"},
 			expected: ast.Variable{

--- a/eval_test.go
+++ b/eval_test.go
@@ -224,6 +224,51 @@ func TestEval(t *testing.T) {
 			TypeString,
 		},
 		{
+			`${foo["bar"]}`,
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeMap,
+						Value: map[string]ast.Variable{
+							"foo": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "hello",
+							},
+							"bar": ast.Variable{
+								Type: ast.TypeUnknown,
+							},
+						},
+					},
+				},
+			},
+			false,
+			UnknownValue,
+			TypeUnknown,
+		},
+		{
+			`${foo["bar"]} foo`,
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeMap,
+						Value: map[string]ast.Variable{
+							"foo": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "hello",
+							},
+							"bar": ast.Variable{
+								Type: ast.TypeUnknown,
+							},
+						},
+					},
+				},
+			},
+			false,
+			UnknownValue,
+			TypeUnknown,
+		},
+
+		{
 			`${foo[3]}`,
 			&ast.BasicScope{
 				VarMap: map[string]ast.Variable{
@@ -325,6 +370,23 @@ func TestEval(t *testing.T) {
 			TypeString,
 		},
 		{
+			`${foo} ${bar}`,
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type:  ast.TypeString,
+						Value: "Hello",
+					},
+					"bar": ast.Variable{
+						Type: ast.TypeUnknown,
+					},
+				},
+			},
+			false,
+			UnknownValue,
+			TypeUnknown,
+		},
+		{
 			`${foo}`,
 			&ast.BasicScope{
 				VarMap: map[string]ast.Variable{
@@ -407,6 +469,64 @@ func TestEval(t *testing.T) {
 			false,
 			"value",
 			TypeString,
+		},
+		{
+			`${foo[upper(bar)]}`,
+			&ast.BasicScope{
+				FuncMap: map[string]ast.Function{
+					"upper": ast.Function{
+						ArgTypes:   []ast.Type{ast.TypeString},
+						ReturnType: ast.TypeString,
+						Callback: func(args []interface{}) (interface{}, error) {
+							return strings.ToUpper(args[0].(string)), nil
+						},
+					},
+				},
+				VarMap: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeMap,
+						Value: map[string]ast.Variable{
+							"KEY": ast.Variable{
+								Type:  ast.TypeString,
+								Value: "value",
+							},
+						},
+					},
+					"bar": ast.Variable{
+						Type: ast.TypeUnknown,
+					},
+				},
+			},
+			false,
+			UnknownValue,
+			TypeUnknown,
+		},
+		{
+			`${upper(foo)}`,
+			&ast.BasicScope{
+				FuncMap: map[string]ast.Function{
+					"upper": ast.Function{
+						ArgTypes:   []ast.Type{ast.TypeMap},
+						ReturnType: ast.TypeString,
+						Callback: func(args []interface{}) (interface{}, error) {
+							return "foo", nil
+						},
+					},
+				},
+				VarMap: map[string]ast.Variable{
+					"foo": ast.Variable{
+						Type: ast.TypeMap,
+						Value: map[string]ast.Variable{
+							"KEY": ast.Variable{
+								Type: ast.TypeUnknown,
+							},
+						},
+					},
+				},
+			},
+			false,
+			UnknownValue,
+			TypeUnknown,
 		},
 	}
 

--- a/eval_type.go
+++ b/eval_type.go
@@ -11,4 +11,5 @@ const (
 	TypeString  EvalType = 1 << iota
 	TypeList
 	TypeMap
+	TypeUnknown
 )


### PR DESCRIPTION
This is a special type (and sentinel value for InterfaceToVariable)
where any operation against it results in a TypeUnknown result. You can
see the tests to see how that works.

This is nice because if you have something like a function, map, or list
that DOESN'T result in an unknown value then the evaluation will work,
but if you happen to access an unknown value at runtime, hil as a whole
will return the unknown value immediately.

This helps Terraform tremendously because it can stop special casing
unknown values and actual mark them as such as just give them to HIL for
normal evaluation all the time. If HIL returns TypeUnknown, then
Terraform knows the value is computed. If in Terraform this happens at
apply-time, then its an error (no computed values during apply).

This has zero effect on previous HIL programs: it is impossible to
arbitrarily introduce "TypeUnknown" unless explicitly passed in by the
HIL caller (not the HIL program).

And, other uses of HIL actually could very well have computed values
(thinking Nomad here) and now that HIL supports it 1st class we can just
magically use it.