### PR TITLE
Arithmetic operator precedence rules

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -707,7 +707,7 @@ func TestEvalInternal(t *testing.T) {
 			"foo ${42+2*2}",
 			nil,
 			false,
-			"foo 88",
+			"foo 46",
 			ast.TypeString,
 		},
 

--- a/parser/binary_op.go
+++ b/parser/binary_op.go
@@ -1,0 +1,29 @@
+package parser
+
+import (
+	"github.com/hashicorp/hil/ast"
+	"github.com/hashicorp/hil/scanner"
+)
+
+var binaryOps []map[scanner.TokenType]ast.ArithmeticOp
+
+func init() {
+	// This operation table maps from the operator's scanner token type
+	// to the AST arithmetic operation. All expressions produced from
+	// binary operators are *ast.Arithmetic nodes.
+	//
+	// Binary operator groups are listed in order of precedence, with
+	// the *lowest* precedence first. Operators within the same group
+	// have left-to-right associativity.
+	binaryOps = []map[scanner.TokenType]ast.ArithmeticOp{
+		{
+			scanner.PLUS:  ast.ArithmeticOpAdd,
+			scanner.MINUS: ast.ArithmeticOpSub,
+		},
+		{
+			scanner.STAR:    ast.ArithmeticOpMul,
+			scanner.SLASH:   ast.ArithmeticOpDiv,
+			scanner.PERCENT: ast.ArithmeticOpMod,
+		},
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -514,6 +514,7 @@ func TestParser(t *testing.T) {
 		},
 
 		{
+			// * has higher precedence than +
 			"${42+2*2}",
 			false,
 			&ast.Output{
@@ -521,7 +522,83 @@ func TestParser(t *testing.T) {
 				Exprs: []ast.Node{
 					&ast.Arithmetic{
 						Posx: ast.Pos{Column: 3, Line: 1},
+						Op:   ast.ArithmeticOpAdd,
+						Exprs: []ast.Node{
+							&ast.LiteralNode{
+								Posx:  ast.Pos{Column: 3, Line: 1},
+								Value: 42,
+								Typex: ast.TypeInt,
+							},
+							&ast.Arithmetic{
+								Posx: ast.Pos{Column: 6, Line: 1},
+								Op:   ast.ArithmeticOpMul,
+								Exprs: []ast.Node{
+									&ast.LiteralNode{
+										Posx:  ast.Pos{Column: 6, Line: 1},
+										Value: 2,
+										Typex: ast.TypeInt,
+									},
+									&ast.LiteralNode{
+										Posx:  ast.Pos{Column: 8, Line: 1},
+										Value: 2,
+										Typex: ast.TypeInt,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			// parentheses override precedence rules
+			"${(42+2)*2}",
+			false,
+			&ast.Output{
+				Posx: ast.Pos{Column: 1, Line: 1},
+				Exprs: []ast.Node{
+					&ast.Arithmetic{
+						Posx: ast.Pos{Column: 3, Line: 1},
 						Op:   ast.ArithmeticOpMul,
+						Exprs: []ast.Node{
+							&ast.Arithmetic{
+								Posx: ast.Pos{Column: 4, Line: 1},
+								Op:   ast.ArithmeticOpAdd,
+								Exprs: []ast.Node{
+									&ast.LiteralNode{
+										Posx:  ast.Pos{Column: 4, Line: 1},
+										Value: 42,
+										Typex: ast.TypeInt,
+									},
+									&ast.LiteralNode{
+										Posx:  ast.Pos{Column: 7, Line: 1},
+										Value: 2,
+										Typex: ast.TypeInt,
+									},
+								},
+							},
+							&ast.LiteralNode{
+								Posx:  ast.Pos{Column: 10, Line: 1},
+								Value: 2,
+								Typex: ast.TypeInt,
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			// Left-associative parsing of operators with equal precedence
+			"${42+2+2}",
+			false,
+			&ast.Output{
+				Posx: ast.Pos{Column: 1, Line: 1},
+				Exprs: []ast.Node{
+					&ast.Arithmetic{
+						Posx: ast.Pos{Column: 3, Line: 1},
+						Op:   ast.ArithmeticOpAdd,
 						Exprs: []ast.Node{
 							&ast.Arithmetic{
 								Posx: ast.Pos{Column: 3, Line: 1},
@@ -541,6 +618,55 @@ func TestParser(t *testing.T) {
 							},
 							&ast.LiteralNode{
 								Posx:  ast.Pos{Column: 8, Line: 1},
+								Value: 2,
+								Typex: ast.TypeInt,
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			// Unary - has higher precedence than addition
+			"${42+-2+2}",
+			false,
+			&ast.Output{
+				Posx: ast.Pos{Column: 1, Line: 1},
+				Exprs: []ast.Node{
+					&ast.Arithmetic{
+						Posx: ast.Pos{Column: 3, Line: 1},
+						Op:   ast.ArithmeticOpAdd,
+						Exprs: []ast.Node{
+							&ast.Arithmetic{
+								Posx: ast.Pos{Column: 3, Line: 1},
+								Op:   ast.ArithmeticOpAdd,
+								Exprs: []ast.Node{
+									&ast.LiteralNode{
+										Posx:  ast.Pos{Column: 3, Line: 1},
+										Value: 42,
+										Typex: ast.TypeInt,
+									},
+									&ast.Arithmetic{
+										Posx: ast.Pos{Column: 6, Line: 1},
+										Op:   ast.ArithmeticOpSub,
+										Exprs: []ast.Node{
+											&ast.LiteralNode{
+												Posx:  ast.Pos{Column: 6, Line: 1},
+												Value: 0,
+												Typex: ast.TypeInt,
+											},
+											&ast.LiteralNode{
+												Posx:  ast.Pos{Column: 7, Line: 1},
+												Value: 2,
+												Typex: ast.TypeInt,
+											},
+										},
+									},
+								},
+							},
+							&ast.LiteralNode{
+								Posx:  ast.Pos{Column: 9, Line: 1},
 								Value: 2,
 								Typex: ast.TypeInt,
 							},


### PR DESCRIPTION
Previously all operators had equal precedence and they were all parsed in a left-associative manner. This was a simple rule, but it was counter-intuitive to people familiar with conventional expression notation or other languages with precedence rules.

Here we give multiplication and division higher precedence than addition and subtraction, so that e.g. `1+2*3` will parse as `1+(2*3)` rather than `(1+2)*3` as before. This is a breaking change for anyone that was depending on the old left-associative parsing behavior, but I assume that this will be relatively few people simply because the old behavior was so counter-intuitive that users are likely to have used explicit parentheses to make their code understandable.

This implementation just uses the standard Go stack to keep track of the nested parsing states required to process the levels of precedence. With only two levels of precedence this is a no-brainer, and this approach should suffice for any reasonable number of levels of precedence.

This is one of the follow-on changes I proposed in #32, and (if included into Terraform) resolves hashicorp/terraform#9169. I chose to attack this one of the proposals first because I figured that if it will be included into Terraform 0.8 it should be included in as many betas and release candidates as possible to give people warning and the opportunity to test existing configs that have non-trivial arithmetic expressions.
