### PR TITLE
Parse indexing [] as a postfix operator

### DIFF
--- a/check_types.go
+++ b/check_types.go
@@ -327,8 +327,7 @@ func (tc *typeCheckIndex) TypeCheck(v *TypeCheck) (ast.Node, error) {
 	// Ensure we have a VariableAccess as the target
 	varAccessNode, ok := tc.n.Target.(*ast.VariableAccess)
 	if !ok {
-		return nil, fmt.Errorf(
-			"target of an index must be a VariableAccess node, was %T", tc.n.Target)
+		return nil, fmt.Errorf("indexing with the [] operator is currently allowed only for variables")
 	}
 
 	// Get the variable

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -196,8 +196,9 @@ func (p *parser) ParseExpression() (ast.Node, error) {
 // for each operand.
 func (p *parser) parseBinaryOps(ops []map[scanner.TokenType]ast.ArithmeticOp) (ast.Node, error) {
 	if len(ops) == 0 {
-		// We've run out of operators, so now we'll just try to parse a term.
-		return p.ParseExpressionTerm()
+		// We've run out of operators, so now we'll just try to parse
+		// terms and postfix operators.
+		return p.parseTermAndPostfixOps()
 	}
 
 	thisLevel := ops[0]
@@ -261,6 +262,33 @@ func (p *parser) parseBinaryOps(ops []map[scanner.TokenType]ast.ArithmeticOp) (a
 	} else {
 		return lhs, nil
 	}
+}
+
+func (p *parser) parseTermAndPostfixOps() (ast.Node, error) {
+	expr, err := p.ParseExpressionTerm()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.peeker.Peek().Type == scanner.OBRACKET {
+		// index operator
+		startPos := p.peeker.Read().Pos // eat bracket
+		indexExpr, err := p.ParseExpression()
+		if err != nil {
+			return nil, err
+		}
+		err = p.requireTokenType(scanner.CBRACKET, `"]"`)
+		if err != nil {
+			return nil, err
+		}
+		expr = &ast.Index{
+			Target: expr,
+			Key:    indexExpr,
+			Posx:   startPos,
+		}
+	}
+
+	return expr, nil
 }
 
 func (p *parser) ParseExpressionTerm() (ast.Node, error) {
@@ -428,24 +456,6 @@ func (p *parser) ParseScopeInteraction() (ast.Node, error) {
 	varNode := &ast.VariableAccess{
 		Name: varName,
 		Posx: startPos,
-	}
-
-	if p.peeker.Peek().Type == scanner.OBRACKET {
-		// index operator
-		startPos := p.peeker.Read().Pos // eat bracket
-		indexExpr, err := p.ParseExpression()
-		if err != nil {
-			return nil, err
-		}
-		err = p.requireTokenType(scanner.CBRACKET, `"]"`)
-		if err != nil {
-			return nil, err
-		}
-		return &ast.Index{
-			Target: varNode,
-			Key:    indexExpr,
-			Posx:   startPos,
-		}, nil
 	}
 
 	return varNode, nil

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -475,6 +475,65 @@ func TestParser(t *testing.T) {
 		},
 
 		{
+			"${foo[1][2]}",
+			false,
+			&ast.Output{
+				Posx: ast.Pos{Column: 1, Line: 1},
+				Exprs: []ast.Node{
+					&ast.Index{
+						Posx: ast.Pos{Column: 9, Line: 1},
+						Target: &ast.Index{
+							Posx: ast.Pos{Column: 6, Line: 1},
+							Target: &ast.VariableAccess{
+								Name: "foo",
+								Posx: ast.Pos{Column: 3, Line: 1},
+							},
+							Key: &ast.LiteralNode{
+								Value: 1,
+								Typex: ast.TypeInt,
+								Posx:  ast.Pos{Column: 7, Line: 1},
+							},
+						},
+						Key: &ast.LiteralNode{
+							Value: 2,
+							Typex: ast.TypeInt,
+							Posx:  ast.Pos{Column: 10, Line: 1},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			"${foo(1)[2]}",
+			false,
+			&ast.Output{
+				Posx: ast.Pos{Column: 1, Line: 1},
+				Exprs: []ast.Node{
+					&ast.Index{
+						Posx: ast.Pos{Column: 9, Line: 1},
+						Target: &ast.Call{
+							Posx: ast.Pos{Column: 3, Line: 1},
+							Func: "foo",
+							Args: []ast.Node{
+								&ast.LiteralNode{
+									Value: 1,
+									Typex: ast.TypeInt,
+									Posx:  ast.Pos{Column: 7, Line: 1},
+								},
+							},
+						},
+						Key: &ast.LiteralNode{
+							Value: 2,
+							Typex: ast.TypeInt,
+							Posx:  ast.Pos{Column: 10, Line: 1},
+						},
+					},
+				},
+			},
+		},
+
+		{
 			"${foo[1]} - ${bar[0]}",
 			false,
 			&ast.Output{
@@ -711,12 +770,6 @@ func TestParser(t *testing.T) {
 					},
 				},
 			},
-		},
-
-		{
-			"${foo[1][2]}",
-			true,
-			nil,
 		},
 
 		{


### PR DESCRIPTION
Previously indexing was treated as a part of variable access, which meant it couldn't be applied to non-variable expressions such as the result of a function.

Now indexing is treated as a postfix operator in its own right, meaning that it can follow any expression term.

This change is backward-compatible because a postfix operator following a variable access produces an AST identical to the previous, and other uses of brackets were previously a syntax error.

The main reason for this is to allow constructions like `split(" ", foo)[0]` in Terraform. Currently such things must be done with the `element` function. With this in place it's likely that we can drop the `element` function from Terraform in a future release. (so we might want to mark it as deprecated now?)