### PR TITLE
Correctly handle escaped quotes inside nested literals

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -153,6 +153,9 @@ func (p *parser) parseStringToken(tok *scanner.Token) (string, error) {
 			case 'n':
 				b = '\n'
 				i++
+			case '"':
+				b = '"'
+				i++
 			default:
 				return "", Errorf(
 					ast.Pos{

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -176,6 +176,26 @@ func TestParser(t *testing.T) {
 		},
 
 		{
+			`foo ${"bar \"baz\""}`,
+			false,
+			&ast.Output{
+				Posx: ast.Pos{Column: 1, Line: 1},
+				Exprs: []ast.Node{
+					&ast.LiteralNode{
+						Value: "foo ",
+						Typex: ast.TypeString,
+						Posx:  ast.Pos{Column: 1, Line: 1},
+					},
+					&ast.LiteralNode{
+						Value: `bar "baz"`,
+						Typex: ast.TypeString,
+						Posx:  ast.Pos{Column: 8, Line: 1},
+					},
+				},
+			},
+		},
+
+		{
 			`foo ${func('baz')}`,
 			true,
 			nil,


### PR DESCRIPTION
Previously the scanner was correctly handling these but the parser was missing the case to replace the escape sequence with a literal quote, resulting in a parse error.

This fixes #35.