### PR TITLE
LiteralNode factory function

### DIFF
--- a/ast/literal.go
+++ b/ast/literal.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"fmt"
+	"reflect"
 )
 
 // LiteralNode represents a single literal value, such as "foo" or
@@ -10,6 +11,51 @@ type LiteralNode struct {
 	Value interface{}
 	Typex Type
 	Posx  Pos
+}
+
+// NewLiteralNode returns a new literal node representing the given
+// literal Go value, which must correspond to one of the primitive types
+// supported by HIL. Lists and maps cannot currently be constructed via
+// this function.
+//
+// If an inappropriately-typed value is provided, this function will
+// return an error. The main intended use of this function is to produce
+// "synthetic" literals from constants in code, where the value type is
+// well known at compile time. To easily store these in global variables,
+// see also MustNewLiteralNode.
+func NewLiteralNode(value interface{}, pos Pos) (*LiteralNode, error) {
+	goType := reflect.TypeOf(value)
+	var hilType Type
+
+	switch goType.Kind() {
+	case reflect.Bool:
+		hilType = TypeBool
+	case reflect.Int:
+		hilType = TypeInt
+	case reflect.Float64:
+		hilType = TypeFloat
+	case reflect.String:
+		hilType = TypeString
+	default:
+		return nil, fmt.Errorf("unsupported literal node type: %T", value)
+	}
+
+	return &LiteralNode{
+		Value: value,
+		Typex: hilType,
+		Posx:  pos,
+	}, nil
+}
+
+// MustNewLiteralNode wraps NewLiteralNode and panics if an error is
+// returned, thus allowing valid literal nodes to be easily assigned to
+// global variables.
+func MustNewLiteralNode(value interface{}, pos Pos) *LiteralNode {
+	node, err := NewLiteralNode(value, pos)
+	if err != nil {
+		panic(err)
+	}
+	return node
 }
 
 func (n *LiteralNode) Accept(v Visitor) Node {

--- a/ast/literal_test.go
+++ b/ast/literal_test.go
@@ -1,6 +1,8 @@
 package ast
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -12,5 +14,66 @@ func TestLiteralNodeType(t *testing.T) {
 	}
 	if actual != TypeString {
 		t.Fatalf("bad: %s", actual)
+	}
+}
+
+func TestNewLiteralNode(t *testing.T) {
+	tests := []struct {
+		Value    interface{}
+		Expected *LiteralNode
+	}{
+		{
+			1,
+			&LiteralNode{
+				Value: 1,
+				Typex: TypeInt,
+			},
+		},
+		{
+			1.0,
+			&LiteralNode{
+				Value: 1.0,
+				Typex: TypeFloat,
+			},
+		},
+		{
+			true,
+			&LiteralNode{
+				Value: true,
+				Typex: TypeBool,
+			},
+		},
+		{
+			"hi",
+			&LiteralNode{
+				Value: "hi",
+				Typex: TypeString,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%T", test.Value), func(t *testing.T) {
+			inPos := Pos{
+				Column:   2,
+				Line:     3,
+				Filename: "foo",
+			}
+			node, err := NewLiteralNode(test.Value, inPos)
+
+			if err != nil {
+				t.Fatalf("error: %s", err)
+			}
+
+			if got, want := node.Typex, test.Expected.Typex; want != got {
+				t.Errorf("got type %s; want %s", got, want)
+			}
+			if got, want := node.Value, test.Expected.Value; want != got {
+				t.Errorf("got value %#v; want %#v", got, want)
+			}
+			if got, want := node.Posx, inPos; !reflect.DeepEqual(got, want) {
+				t.Errorf("got position %#v; want %#v", got, want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Sometimes a caller wants to return a "synthetic" literal based on some Go value it is holding, such as a default placeholder value that can optionally be overridden by a HIL expression.

This new function helps callers do this robustly, selecting the appropriate value for the `Typex` attribute based on the dynamic type of the provided value.

For now this supports only primitive types. Later it could be interesting to support recursive construction of lists and maps from Go slices and maps, but for now we keep this relatively simple.

The primary motivation for this change is to support hashicorp/hcl#171.