### PR TITLE
Parse "foo.bar" as a single identifier

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"strconv"
-	"strings"
 	"unicode/utf8"
 
 	"github.com/hashicorp/hil/ast"
@@ -483,26 +482,8 @@ func (p *parser) ParseScopeInteraction() (ast.Node, error) {
 		}, nil
 	}
 
-	varParts := []string{first.Content}
-	for p.peeker.Peek().Type == scanner.PERIOD {
-		p.peeker.Read() // eat period
-
-		// Read the next item, since variable access in HIL is composed
-		// of many things. For example: "var.0.bar" is the entire var access.
-		partTok := p.peeker.Read()
-		switch partTok.Type {
-		case scanner.IDENTIFIER:
-		case scanner.STAR:
-		case scanner.INTEGER:
-		default:
-			return nil, ExpectationError("identifier", partTok)
-		}
-
-		varParts = append(varParts, partTok.Content)
-	}
-	varName := strings.Join(varParts, ".")
 	varNode := &ast.VariableAccess{
-		Name: varName,
+		Name: first.Content,
 		Posx: startPos,
 	}
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -54,6 +54,20 @@ func TestParser(t *testing.T) {
 			},
 		},
 
+		// Identifier starting with a number
+		{
+			`foo ${123abcd}`,
+			true,
+			nil,
+		},
+
+		// Identifier starting with a *
+		{
+			`foo ${*abcd}`,
+			true,
+			nil,
+		},
+
 		{
 			"foo ${var.bar}",
 			false,
@@ -67,6 +81,25 @@ func TestParser(t *testing.T) {
 					},
 					&ast.VariableAccess{
 						Name: "var.bar",
+						Posx: ast.Pos{Column: 7, Line: 1},
+					},
+				},
+			},
+		},
+
+		{
+			"foo ${var.bar.*.baz}",
+			false,
+			&ast.Output{
+				Posx: ast.Pos{Column: 1, Line: 1},
+				Exprs: []ast.Node{
+					&ast.LiteralNode{
+						Value: "foo ",
+						Typex: ast.TypeString,
+						Posx:  ast.Pos{Column: 1, Line: 1},
+					},
+					&ast.VariableAccess{
+						Name: "var.bar.*.baz",
 						Posx: ast.Pos{Column: 7, Line: 1},
 					},
 				},

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -479,9 +479,28 @@ func scanIdentifier(s string) (string, int) {
 		nextRune, size := utf8.DecodeRuneInString(s[byteLen:])
 		if !(nextRune == '_' ||
 			nextRune == '-' ||
+			nextRune == '.' ||
+			nextRune == '*' ||
 			unicode.IsNumber(nextRune) ||
 			unicode.IsLetter(nextRune) ||
 			unicode.IsMark(nextRune)) {
+			break
+		}
+
+		// If we reach a star, it must be between periods to be part
+		// of the same identifier.
+		if nextRune == '*' && s[byteLen-1] != '.' {
+			break
+		}
+
+		// If our previous character was a star, then the current must
+		// be period. Otherwise, undo that and exit.
+		if byteLen > 0 && s[byteLen-1] == '*' && nextRune != '.' {
+			byteLen--
+			if s[byteLen-1] == '.' {
+				byteLen--
+			}
+
 			break
 		}
 

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -64,13 +64,12 @@ func TestScanner(t *testing.T) {
 
 		{
 			"foo ${bar.0.baz}",
-			[]TokenType{LITERAL, BEGIN, IDENTIFIER, PERIOD, INTEGER, PERIOD, IDENTIFIER, END, EOF},
+			[]TokenType{LITERAL, BEGIN, IDENTIFIER, END, EOF},
 		},
 
 		{
 			"foo ${bar.foo-bar.baz}",
-			[]TokenType{LITERAL, BEGIN, IDENTIFIER, PERIOD, IDENTIFIER,
-				PERIOD, IDENTIFIER, END, EOF},
+			[]TokenType{LITERAL, BEGIN, IDENTIFIER, END, EOF},
 		},
 
 		{
@@ -253,7 +252,7 @@ func TestScanner(t *testing.T) {
 			[]TokenType{
 				LITERAL,
 				BEGIN,
-				IDENTIFIER, PERIOD, IDENTIFIER, PERIOD, IDENTIFIER,
+				IDENTIFIER,
 				END, EOF,
 			},
 		},
@@ -263,7 +262,37 @@ func TestScanner(t *testing.T) {
 			[]TokenType{
 				LITERAL,
 				BEGIN,
-				IDENTIFIER, PERIOD, IDENTIFIER, PERIOD, STAR, PERIOD, IDENTIFIER,
+				IDENTIFIER,
+				END, EOF,
+			},
+		},
+
+		{
+			"foo ${foo.bar.*}",
+			[]TokenType{
+				LITERAL,
+				BEGIN,
+				IDENTIFIER,
+				END, EOF,
+			},
+		},
+
+		{
+			"foo ${foo.bar.*baz}",
+			[]TokenType{
+				LITERAL,
+				BEGIN,
+				IDENTIFIER, PERIOD, STAR, IDENTIFIER,
+				END, EOF,
+			},
+		},
+
+		{
+			"foo ${foo*}",
+			[]TokenType{
+				LITERAL,
+				BEGIN,
+				IDENTIFIER, STAR,
 				END, EOF,
 			},
 		},
@@ -285,7 +314,7 @@ func TestScanner(t *testing.T) {
 				BEGIN,
 				OQUOTE,
 				BEGIN,
-				IDENTIFIER, PERIOD, IDENTIFIER,
+				IDENTIFIER,
 				END,
 				CQUOTE,
 				END,


### PR DESCRIPTION
This fixes #40 in a way that is consistent:

  * Identifiers may not begin with numbers.

  * Identifiers are parsed as a complete sequence, so "var.123" is
    now a single identifier.

This should fix the case of variables and resource names starting with
numbers in Terraform without compromising on identifiers starting with
characters. This is because accessing these in Terraform is always
qualified with a prefix anyways.

I can see the use case for PERIOD being a separate token but its
unlikely we'll ever be able to use that for anything other than identifiers
due to historical reasons with HIL. 