### PR TITLE
promote to float math above all else

### DIFF
--- a/check_types.go
+++ b/check_types.go
@@ -135,20 +135,11 @@ func (tc *typeCheckArithmetic) checkNumeric(v *TypeCheck, exprs []ast.Type) (ast
 	mathFunc := "__builtin_IntMath"
 	mathType := ast.TypeInt
 	for _, v := range exprs {
-		exit := true
-		switch v {
-		case ast.TypeInt:
-			mathFunc = "__builtin_IntMath"
-			mathType = v
-		case ast.TypeFloat:
+		// We assume int math but if we find ANY float, the entire
+		// expression turns into floating point math.
+		if v == ast.TypeFloat {
 			mathFunc = "__builtin_FloatMath"
 			mathType = v
-		default:
-			exit = false
-		}
-
-		// We found the type, so leave
-		if exit {
 			break
 		}
 	}

--- a/eval_test.go
+++ b/eval_test.go
@@ -704,6 +704,22 @@ func TestEvalInternal(t *testing.T) {
 		},
 
 		{
+			"foo ${0.5 * 75}",
+			nil,
+			false,
+			"foo 37.5",
+			ast.TypeString,
+		},
+
+		{
+			"foo ${75 * 0.5}",
+			nil,
+			false,
+			"foo 37.5",
+			ast.TypeString,
+		},
+
+		{
 			"foo ${42+2*2}",
 			nil,
 			false,


### PR DESCRIPTION
Fixes #43

If any element in a mathematical expression is a float, HIL should
promote the entire expression to float math.