### PR TITLE
implicitly convert string to numeric for comparison

### DIFF
--- a/check_types.go
+++ b/check_types.go
@@ -119,7 +119,9 @@ func (tc *typeCheckArithmetic) TypeCheck(v *TypeCheck) (ast.Node, error) {
 	switch tc.n.Op {
 	case ast.ArithmeticOpLogicalAnd, ast.ArithmeticOpLogicalOr:
 		return tc.checkLogical(v, exprs)
-	case ast.ArithmeticOpEqual, ast.ArithmeticOpNotEqual, ast.ArithmeticOpLessThan, ast.ArithmeticOpGreaterThan, ast.ArithmeticOpGreaterThanOrEqual, ast.ArithmeticOpLessThanOrEqual:
+	case ast.ArithmeticOpEqual, ast.ArithmeticOpNotEqual,
+		ast.ArithmeticOpLessThan, ast.ArithmeticOpGreaterThan,
+		ast.ArithmeticOpGreaterThanOrEqual, ast.ArithmeticOpLessThanOrEqual:
 		return tc.checkComparison(v, exprs)
 	default:
 		return tc.checkNumeric(v, exprs)
@@ -184,7 +186,6 @@ func (tc *typeCheckArithmetic) checkNumeric(v *TypeCheck, exprs []ast.Type) (ast
 }
 
 func (tc *typeCheckArithmetic) checkComparison(v *TypeCheck, exprs []ast.Type) (ast.Node, error) {
-
 	if len(exprs) != 2 {
 		// This should never happen, because the parser never produces
 		// nodes that violate this.
@@ -209,6 +210,22 @@ func (tc *typeCheckArithmetic) checkComparison(v *TypeCheck, exprs []ast.Type) (
 		return nil, fmt.Errorf(
 			"comparison operators apply only to bool, float, int, and string",
 		)
+	}
+
+	// For non-equality comparisons, we will do implicit conversions to
+	// integer types if possible. In this case, we need to go through and
+	// determine the type of comparison we're doing to enable the implicit
+	// conversion.
+	if tc.n.Op != ast.ArithmeticOpEqual && tc.n.Op != ast.ArithmeticOpNotEqual {
+		compareFunc = "__builtin_IntCompare"
+		compareType = ast.TypeInt
+		for _, expr := range exprs {
+			if expr == ast.TypeFloat {
+				compareFunc = "__builtin_FloatCompare"
+				compareType = ast.TypeFloat
+				break
+			}
+		}
 	}
 
 	// Verify (and possibly, convert) the args

--- a/eval_test.go
+++ b/eval_test.go
@@ -1602,6 +1602,51 @@ func TestEvalInternal(t *testing.T) {
 			"foo -36",
 			ast.TypeString,
 		},
+
+		{
+			"${var.foo > 1 ? 5 : 0}",
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"var.foo": ast.Variable{
+						Type:  ast.TypeString,
+						Value: "3",
+					},
+				},
+			},
+			false,
+			"5",
+			ast.TypeString,
+		},
+
+		{
+			"${var.foo > 1.5 ? 5 : 0}",
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"var.foo": ast.Variable{
+						Type:  ast.TypeString,
+						Value: "3",
+					},
+				},
+			},
+			false,
+			"5",
+			ast.TypeString,
+		},
+
+		{
+			"${var.foo > 1.5 ? 5 : 0}",
+			&ast.BasicScope{
+				VarMap: map[string]ast.Variable{
+					"var.foo": ast.Variable{
+						Type:  ast.TypeString,
+						Value: "1.2",
+					},
+				},
+			},
+			false,
+			"0",
+			ast.TypeString,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
This implicitly converts string to int or float for comparison operators
>, <, <=, >=.