### PR TITLE
Allow partially-unknown collection values

### DIFF
--- a/ast/literal.go
+++ b/ast/literal.go
@@ -77,3 +77,12 @@ func (n *LiteralNode) String() string {
 func (n *LiteralNode) Type(Scope) (Type, error) {
 	return n.Typex, nil
 }
+
+// IsUnknown returns true either if the node's value is itself unknown
+// of if it is a collection containing any unknown elements, deeply.
+func (n *LiteralNode) IsUnknown() bool {
+	return IsUnknown(Variable{
+		Type:  n.Typex,
+		Value: n.Value,
+	})
+}

--- a/eval.go
+++ b/eval.go
@@ -54,6 +54,14 @@ func Eval(root ast.Node, config *EvalConfig) (EvaluationResult, error) {
 		return InvalidResult, err
 	}
 
+	// If the result contains any nested unknowns then the result as a whole
+	// is unknown, so that callers only have to deal with "entirely known"
+	// or "entirely unknown" as outcomes.
+	if ast.IsUnknown(ast.Variable{Type: outputType, Value: output}) {
+		outputType = ast.TypeUnknown
+		output = UnknownValue
+	}
+
 	switch outputType {
 	case ast.TypeList:
 		val, err := VariableToInterface(ast.Variable{
@@ -264,6 +272,10 @@ func (v *evalCall) Eval(s ast.Scope, stack *ast.Stack) (interface{}, ast.Type, e
 	args := make([]interface{}, len(v.Args))
 	for i, _ := range v.Args {
 		node := stack.Pop().(*ast.LiteralNode)
+		if node.IsUnknown() {
+			// If any arguments are unknown then the result is automatically unknown
+			return UnknownValue, ast.TypeUnknown, nil
+		}
 		args[len(v.Args)-1-i] = node.Value
 	}
 
@@ -286,6 +298,11 @@ func (v *evalConditional) Eval(s ast.Scope, stack *ast.Stack) (interface{}, ast.
 	trueLit := stack.Pop().(*ast.LiteralNode)
 	condLit := stack.Pop().(*ast.LiteralNode)
 
+	if condLit.IsUnknown() {
+		// If our conditional is unknown then our result is also unknown
+		return UnknownValue, ast.TypeUnknown, nil
+	}
+
 	if condLit.Value.(bool) {
 		return trueLit.Value, trueLit.Typex, nil
 	} else {
@@ -300,6 +317,17 @@ func (v *evalIndex) Eval(scope ast.Scope, stack *ast.Stack) (interface{}, ast.Ty
 	target := stack.Pop().(*ast.LiteralNode)
 
 	variableName := v.Index.Target.(*ast.VariableAccess).Name
+
+	if key.IsUnknown() {
+		// If our key is unknown then our result is also unknown
+		return UnknownValue, ast.TypeUnknown, nil
+	}
+
+	// For target, we'll accept collections containing unknown values but
+	// we still need to catch when the collection itself is unknown, shallowly.
+	if target.Typex == ast.TypeUnknown {
+		return UnknownValue, ast.TypeUnknown, nil
+	}
 
 	switch target.Typex {
 	case ast.TypeList:
@@ -396,6 +424,9 @@ func (v *evalOutput) Eval(s ast.Scope, stack *ast.Stack) (interface{}, ast.Type,
 	// Otherwise concatenate the strings
 	var buf bytes.Buffer
 	for i := len(nodes) - 1; i >= 0; i-- {
+		if nodes[i].IsUnknown() {
+			return UnknownValue, ast.TypeUnknown, nil
+		}
 		buf.WriteString(nodes[i].Value.(string))
 	}
 
@@ -416,12 +447,6 @@ func (v *evalVariableAccess) Eval(scope ast.Scope, _ *ast.Stack) (interface{}, a
 	if !ok {
 		return nil, ast.TypeInvalid, fmt.Errorf(
 			"unknown variable accessed: %s", v.Name)
-	}
-
-	// Check if the variable contains any unknown types. If so, then
-	// mark it as unknown and return that type.
-	if ast.IsUnknown(variable) {
-		return nil, ast.TypeUnknown, nil
 	}
 
 	return variable.Value, variable.Type, nil


### PR DESCRIPTION
Previously there was a hard rule that if a list or map contains any unknown values then the collection as a whole is unknown. This kept the handling of this situation in one spot, but was non-ideal since it is safe to use the index operator `[...]` on a partially-unknown list or map and access the values that *are* known.

This change removes the unilateral rule that any nested unknowns immediately collapse to a single top-level unknown, which then requires each of the eval node implementations to provide their own handling of unknowns. In return for this extra complexity, we are able to make an exception in the handling of the index operator to allow the retrieval of any known values in a partially-unknown collection.

The new rules are:

  - If the ultimate evaluation result is a partially-unknown collection, we flatten to a top-level unknown before returning in order to keep things simple for callers.

  - When evaluating a function call, if any arguments are unknown or contain any unknowns then we skip calling the function and immediately return unknown. This avoids the need for function implementations to consider unknown values.

  - Arithmetic operators are lowered to calls to builtin functions, so these are dealt with using the same logic as function calls.

  - When evaluating `? :` conditionals, if the condition itself is unknown then the result is unknown. We don't check the known-ness of the two result values, since passing through an unknown here is fine.

  - For the index operator `[...]` we return unknown if the collection itself is unknown as a whole, or if the key is unknown. Otherwise we just take the value from the collection, accepting that it might itself be unknown.

  - For output nodes, if any of the concatenated nodes are unknown then the entire result is unknown.

These new rules are covered by some additional test cases since now it's well worth testing the `TypeUnknown` handling for each node type separately.

The primary use-case for this is dealing with Terraform's "splat syntax", which allows retrieving a list of attribute values from a list of instances of a single resource, like `aws_instance.foo.*.id`. Currently
this is problematic because adding a new instance (by increasing "count") adds a new computed item to the end of this list and in turn makes the whole list become Unknown. With this change, only the values correponding to the new instances will be considered as Unknown, leaving existing resources undisturbed. This use-case is discussed in more detail in hashicorp/terraform#3449 .
