### PR TITLE
Feature: allow escaping of characters in identifiers

### DIFF
--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -73,6 +73,11 @@ func TestScanner(t *testing.T) {
 		},
 
 		{
+			"foo ${bar.foo\\[bar\\].baz}",
+			[]TokenType{LITERAL, BEGIN, IDENTIFIER, END, EOF},
+		},
+
+		{
 			"foo $${bar}",
 			[]TokenType{LITERAL, EOF},
 		},


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform/issues/17197

This should allow users to escape certain characters that would otherwise be picked up as new identifiers. For a usecase see the ticket related above, I've also added it as a testcase.

I can imagine the Go code I wrote is not acceptable, please let me know how I can improve it if this is something you are interested in supporting.

Thanks!