### PR TITLE
InterfaceToVariable: Maintain backward compatibility

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -47,8 +47,23 @@ func hilMapstructureWeakDecode(m interface{}, rawVal interface{}) error {
 }
 
 func InterfaceToVariable(input interface{}) (ast.Variable, error) {
-	if inputVariable, ok := input.(ast.Variable); ok {
-		return inputVariable, nil
+	if iv, ok := input.(ast.Variable); ok {
+		return iv, nil
+	}
+
+	// This is just to maintain backward compatibility
+	// after https://github.com/mitchellh/mapstructure/pull/98
+	if v, ok := input.([]ast.Variable); ok {
+		return ast.Variable{
+			Type:  ast.TypeList,
+			Value: v,
+		}, nil
+	}
+	if v, ok := input.(map[string]ast.Variable); ok {
+		return ast.Variable{
+			Type:  ast.TypeMap,
+			Value: v,
+		}, nil
 	}
 
 	var stringVal string

--- a/convert_test.go
+++ b/convert_test.go
@@ -8,13 +8,60 @@ import (
 )
 
 func TestInterfaceToVariable_variableInput(t *testing.T) {
-	_, err := InterfaceToVariable(ast.Variable{
-		Type:  ast.TypeString,
-		Value: "Hello world",
-	})
+	testCases := []struct {
+		name     string
+		input    interface{}
+		expected ast.Variable
+	}{
+		{
+			name: "string variable",
+			input: ast.Variable{
+				Type:  ast.TypeString,
+				Value: "Hello world",
+			},
+			expected: ast.Variable{
+				Type:  ast.TypeString,
+				Value: "Hello world",
+			},
+		},
+		{
+			// This is just to maintain backward compatibility
+			// after https://github.com/mitchellh/mapstructure/pull/98
+			name: "slice of variables",
+			input: []ast.Variable{
+				{Type: ast.TypeString, Value: "Hello world"},
+			},
+			expected: ast.Variable{
+				Type: ast.TypeList,
+				Value: []ast.Variable{
+					{Type: ast.TypeString, Value: "Hello world"},
+				},
+			},
+		},
+		{
+			// This is just to maintain backward compatibility
+			// after https://github.com/mitchellh/mapstructure/pull/98
+			name: "map with variables",
+			input: map[string]ast.Variable{
+				"k": {Type: ast.TypeString, Value: "Hello world"},
+			},
+			expected: ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"k": {Type: ast.TypeString, Value: "Hello world"},
+				},
+			},
+		},
+	}
 
-	if err != nil {
-		t.Fatalf("Bad: %s", err)
+	for _, tc := range testCases {
+		output, err := InterfaceToVariable(tc.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(output, tc.expected) {
+			t.Fatalf("%s:\nExpected: %s\n     Got: %s\n", tc.name, tc.expected, output)
+		}
 	}
 }
 

--- a/eval_test.go
+++ b/eval_test.go
@@ -2045,10 +2045,10 @@ func TestEvalInternal(t *testing.T) {
 				t.Fatalf("Error: %s\nInput: %s", err, tc.Input)
 			}
 			if tc.ResultType != ast.TypeInvalid && outType != tc.ResultType {
-				t.Fatalf("Wrong result type\nInput: %s\nGot:   %#s\nWant:  %s", tc.Input, outType, tc.ResultType)
+				t.Fatalf("Wrong result type\nInput: %s\nGot:   %#v\nWant:  %s", tc.Input, outType, tc.ResultType)
 			}
 			if !reflect.DeepEqual(out, tc.Result) {
-				t.Fatalf("Wrong result value\nInput: %s\nGot:   %#s\nWant:  %s", tc.Input, out, tc.Result)
+				t.Fatalf("Wrong result value\nInput: %s\nGot:   %#v\nWant:  %s", tc.Input, out, tc.Result)
 			}
 		})
 	}


### PR DESCRIPTION
This was discovered when upgrading `mitchellh/mapstructure` to its new version which contains https://github.com/mitchellh/mapstructure/pull/98 which in turn caused some tests in `hashicorp/terraform` to fail:

```
--- FAIL: TestInterpolateFuncMap (0.00s)
    --- FAIL: TestInterpolateFuncMap/${map("hello",_list("world"),_"what's",_list("up?"))} (0.00s)
        interpolate_funcs_test.go:2487: wrong result
            given: ${map("hello", list("world"), "what's", list("up?"))}
            got:   map[string]interface {}{"hello":map[string]interface {}{"Value":"world", "Type":"8"}, "what's":map[string]interface {}{"Value":"up?", "Type":"8"}}
            want:  map[string]interface {}{"hello":[]interface {}{"world"}, "what's":[]interface {}{"up?"}}
--- FAIL: TestInterpolateFuncMerge (0.00s)
    --- FAIL: TestInterpolateFuncMerge/${merge(map("a",_list("b")),_map("c",_list("d",_"e")))} (0.00s)
        interpolate_funcs_test.go:2487: wrong result
            given: ${merge(map("a", list("b")), map("c", list("d", "e")))}
            got:   map[string]interface {}{"a":map[string]interface {}{"Value":"b", "Type":"8"}, "c":map[string]interface {}{"Value":"e", "Type":"8"}}
            want:  map[string]interface {}{"a":[]interface {}{"b"}, "c":[]interface {}{"d", "e"}}
    --- FAIL: TestInterpolateFuncMerge/${merge(map("a",_var.maps[0]),_map("b",_list("c",_"d")))} (0.00s)
        interpolate_funcs_test.go:2487: wrong result
            given: ${merge(map("a", var.maps[0]), map("b", list("c", "d")))}
            got:   map[string]interface {}{"a":map[string]interface {}{"key1":"a", "key2":"b"}, "b":map[string]interface {}{"Value":"d", "Type":"8"}}
            want:  map[string]interface {}{"a":map[string]interface {}{"key2":"b", "key1":"a"}, "b":[]interface {}{"c", "d"}}
--- FAIL: TestInterpolateFuncJSONEncode (0.00s)
    --- FAIL: TestInterpolateFuncJSONEncode/${jsonencode(nestedlist)} (0.00s)
        interpolate_funcs_test.go:2487: wrong result
            given: ${jsonencode(nestedlist)}
            got:   "{\"Type\":\"64\",\"Value\":{\"Type\":\"8\",\"Value\":\"foo\"}}"
            want:  "[[\"foo\"]]"
FAIL
FAIL	github.com/hashicorp/terraform/config	0.296s
```

with this patch the mentioned tests pass:

```
$ go test -mod=vendor ./config
ok  	github.com/hashicorp/terraform/config	0.826s
```
