### PR TITLE
Use docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
 jobs:
   linux-tests:
     docker:
-      - image: cimg/go:<< parameters.go-version >>
+      - image: docker.mirror.hashicorp.services/cimg/go:<< parameters.go-version >>
     environment: 
       <<: *ENVIRONMENT
     parameters:
@@ -131,7 +131,7 @@ jobs:
 
   coverage-merge:
     docker:
-      - image: cimg/go:<< parameters.go-version >>
+      - image: docker.mirror.hashicorp.services/cimg/go:<< parameters.go-version >>
     environment: 
       <<: *ENVIRONMENT
     parameters:


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. LMK if you have any q's, otherwise feel free to approve and merge on your own! 